### PR TITLE
Archipelago decks

### DIFF
--- a/db/anygame.js
+++ b/db/anygame.js
@@ -41,6 +41,9 @@ const {
 const tajMahal = require('./decks/tajMahal');
 const unoCards = require('./decks/uno');
 const penguinParty = require('./decks/penguinParty');
+const { archipelagoShortObjectives } = require('./decks/archipelagoShortObjectives');
+const { archipelagoMediumObjectives } = require('./decks/archipelagoMediumObjectives');
+const { archipelagoLongObjectives } = require('./decks/archipelagoLongObjectives');
 
 class GameDatabase {
     
@@ -86,6 +89,9 @@ class GameDatabase {
         [ "Taj Mahal", "taj-mahal"],
         [ "Uno Classic", "uno-classic"],
         [ "Penguin Party", "penguin-party"],
+        [ "Archipelago Short Objectives", "archipelago-short" ],
+        [ "Archipelago Medium Objectives", "archipelago-medium" ],
+        [ "Archipelago Long Objectives", "archipelago-long" ],
     ]
 
     defaultGameData = {
@@ -316,6 +322,12 @@ class GameDatabase {
                 return this.createCardFromObjList(deckName, "B", unoCards);
             case "penguin-party":
                 return this.createCardFromObjList(deckName, "B", penguinParty);
+            case "archipelago-short":
+                return this.createCardFromObjList(deckName, "B", archipelagoShortObjectives);
+            case "archipelago-medium":
+                return this.createCardFromObjList(deckName, "B", archipelagoMediumObjectives);
+            case "archipelago-long":
+                return this.createCardFromObjList(deckName, "B", archipelagoLongObjectives);
             default:
                 return []
         }

--- a/db/decks/archipelagoLongObjectives.js
+++ b/db/decks/archipelagoLongObjectives.js
@@ -1,0 +1,64 @@
+const archipelagoLongObjectives = [
+  {
+    name: "Long Game Objective 1",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of markets in play: 5 markets in a 2-player game, 6 markets in a 3-player game, etc. Victory condition: number of temples controlled by each player"
+  },
+  {
+    name: "Long Game Objective 2",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: any 3 resources run out at the bank. Victory condition: number of ports controlled by each player"
+  },
+  {
+    name: "Long Game Objective 3",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of towns in play: 5 towns in a 2-player game, 6 towns in a 3-player game, etc. Victory condition: number of explorer tokens behind each player's screen"
+  },
+  {
+    name: "Long Game Objective 4",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of ports in play: 5 ports in a 2-player game, 6 ports in a 3-player game, etc. Victory condition: amount of money behind each player's screen"
+  },
+  {
+    name: "Long Game Objective 5",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: all 3 explorer token piles are exhausted. Victory condition: number of character cards controlled by each player"
+  },
+  {
+    name: "Long Game Objective 6",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of ships in play: 6 ships in a 2-player game, 8 ships in a 3-player game, etc. Victory condition: number of progress cards controlled by each player"
+  },
+  {
+    name: "Long Game Objective 7",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of character and progress cards in play: 12 cards in a 2-player game, 16 cards in a 3-player game, etc. Victory condition: Each player adds up the total number of fish resources in regions he controls with towns."
+  },
+  {
+    name: "Long Game Objective 8",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of temples in play: 5 temples in a 2-player game, 6 temples in a 3-player game, etc. Victory condition: Each player adds up the total number of exotic fruit resources in regions he controls with towns."
+  },
+  {
+    name: "Long Game Objective 9",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: surplus workers level higher than 21. Victory condition: Pacifist: If the difference between the population marker and the rebellion marker is higher than 10, the Pacifist alone scores 3 VP."
+  },
+  {
+    name: "Long Game Objective 10",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: bank is out of money. Victory condition: Separatist: If the rebellion marker moves past the population marker, the Separatist wins alone."
+  }
+];
+
+module.exports = { archipelagoLongObjectives };

--- a/db/decks/archipelagoMediumObjectives.js
+++ b/db/decks/archipelagoMediumObjectives.js
@@ -1,0 +1,64 @@
+const archipelagoMediumObjectives = [
+  {
+    name: "Medium Game Objective 1",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of markets in play: 4 markets in a 2-player game, 5 markets in a 3-player game, etc. Victory condition: Each player adds up the total number of wood resources in regions he controls with towns."
+  },
+  {
+    name: "Medium Game Objective 2",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of temples in play: 4 temples in a 2-player game, 5 temples in a 3-player game, etc. Victory condition: total number of character and progress cards controlled by each player"
+  },
+  {
+    name: "Medium Game Objective 3",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of character cards in play: 5 characters in a 2-player game, 8 characters in a 3-player game, etc. Victory condition: number of fish resources behind each player's screen"
+  },
+  {
+    name: "Medium Game Objective 4",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: all 3 explorer token piles are exhausted. Victory condition: Each player adds up the total number of iron resources in regions he controls with towns."
+  },
+  {
+    name: "Medium Game Objective 5",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of ports in play: 4 ports in a 2-player game, 5 ports in a 3-player game, etc. Victory condition: number of temples controlled by each player"
+  },
+  {
+    name: "Medium Game Objective 6",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of progress cards in play: 5 cards in a 2-player game, 8 cards in a 3-player game, etc. Victory condition: amount of money behind each player's screen"
+  },
+  {
+    name: "Medium Game Objective 7",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: total number of towns in play: 4 towns in a 2-player game, 5 towns in a 3-player game, etc. Victory condition: number of explorer tokens behind each player's screen"
+  },
+  {
+    name: "Medium Game Objective 8",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: Population marker reaches or exceeds: 20 citizens in a 2-player game, 27 citizens in a 3-player game, etc. Victory condition: total number of ports and markets controlled by each player"
+  },
+  {
+    name: "Medium Game Objective 9",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: any 3 resources run out at the bank. Victory condition: Pacifist: If the difference between the population marker and the rebellion marker is higher than 12, the Pacifist alone scores 3 VP."
+  },
+  {
+    name: "Medium Game Objective 10",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End-of-game condition: bank is out of money. Victory condition: Separatist: If the rebellion marker moves past the population marker, the Separatist wins alone."
+  }
+];
+
+module.exports = { archipelagoMediumObjectives };

--- a/db/decks/archipelagoShortObjectives.js
+++ b/db/decks/archipelagoShortObjectives.js
@@ -1,0 +1,64 @@
+const archipelagoShortObjectives = [
+  {
+    name: "Short Game Objective 1",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: 2 explorer token piles exhausted. Victory Condition: amount of money behind each player's screen"
+  },
+  {
+    name: "Short Game Objective 2",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of temples in play: 2 temples in a 2-player game, 3 temples in a 3-player game, etc. Victory Condition: number of character cards controlled by each player"
+  },
+  {
+    name: "Short Game Objective 3",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: any 2 resources run out at the bank. Victory Condition: number of temples controlled by each player"
+  },
+  {
+    name: "Short Game Objective 4",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of progress cards in play: 4 cards in a 2-player game, 5 cards in a 3-player game, etc. Victory Condition: number of markets controlled by each player"
+  },
+  {
+    name: "Short Game Objective 5",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of towns in play: 3 towns in a 2-player game, 4 towns in a 3-player game, etc. Victory Condition: number of ports controlled by each player"
+  },
+  {
+    name: "Short Game Objective 6",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of ports in play: 3 ports in a 2-player game, 4 ports in a 3-player game, etc. Victory Condition: number of progress cards controlled by each player"
+  },
+  {
+    name: "Short Game Objective 7",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of character cards in play: 4 characters in a 2-player game, 5 characters in a 3-player game, etc. Victory Condition: number of explorer tokens behind each player's screen"
+  },
+  {
+    name: "Short Game Objective 8",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: total number of markets in play: 3 markets in a 2-player game, 4 markets in a 3-player game, etc. Victory Condition: number of iron resources behind each player's screen"
+  },
+  {
+    name: "Short Game Objective 9",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: Population marker reaches or exceeds: 22 citizens in a 3-player game, etc. (not used in a 2-player game). Victory Condition: Pacifist: If the difference between the population marker and the rebellion marker is higher than 15, the Pacifist alone scores 3 VP."
+  },
+  {
+    name: "Short Game Objective 10",
+    type: "Secret Objective",
+    suit: "Archipelago",
+    description: "End of Game Condition: all 3 explorer token piles exhausted. Victory Condition: Separatist: If the rebellion marker moves past the population marker, the Separatist wins alone."
+  }
+];
+
+module.exports = { archipelagoShortObjectives };


### PR DESCRIPTION
feat: Populate Long Objectives and complete Archipelago decks

This commit updates the Archipelago Long Objectives deck with data you provided.
With this change, all three Archipelago secret objective decks (Short, Medium, and Long) are now fully populated with 10 cards each, and their definitions do not include the 'url' property.

Key changes:
- Replaced placeholder data in `db/decks/archipelagoLongObjectives.js` with 10 specific long objective cards (without the `url` property).
- Updated the display name for the "Archipelago Long Objectives" deck in `db/anygame.js` to remove the "(Placeholder)" suffix.

This completes the implementation of the Archipelago secret objective decks.