### PR TITLE
Refactor: Allow bot to see its own secret tokens in status

### DIFF
--- a/modules/GameFormatter.js
+++ b/modules/GameFormatter.js
@@ -78,7 +78,7 @@ class GameFormatter {
     return newEmbed;
   }
 
-  static async GameStatusV2(gameData, guild) {
+  static async GameStatusV2(gameData, guild, clientUserId) {
     const columns = [
       { title: "Player" },
       { title: "Score", options: { textAlign: "right" } },
@@ -126,14 +126,20 @@ class GameFormatter {
         play.score,
       ];
 
-      // Add token values for each public token
+      // Add token values
       if (gameData.tokens && gameData.tokens.length > 0) {
         gameData.tokens.forEach(token => {
           if (token.isSecret) {
-            rowData.push('?');
+            // Check if the current player is the bot
+            if (play.userId === clientUserId) {
+              const tokenCount = play.tokens?.[token.id] || 0;
+              rowData.push(tokenCount.toString()); // Show bot's own secret token count
+            } else {
+              rowData.push('?'); // Show '?' for other players' secret tokens
+            }
           } else {
             const tokenCount = play.tokens?.[token.id] || 0;
-            rowData.push(tokenCount.toString());
+            rowData.push(tokenCount.toString()); // Show public token counts for all players
           }
         });
       }
@@ -601,8 +607,8 @@ class GameFormatter {
    * @param {Array} options.additionalEmbeds - Optional additional embeds to include
    * @returns {Object} Reply options object compatible with interaction.reply or interaction.editReply
    */
-  static async createGameStatusReply(gameData, guild, options = {}) {
-    const { attachment, embed } = await this.GameStatusV2(gameData, guild);
+  static async createGameStatusReply(gameData, guild, clientUserId, options = {}) {
+    const { attachment, embed } = await this.GameStatusV2(gameData, guild, clientUserId);
 
     // Initialize embeds array for replyOptions
     let finalEmbeds = [];

--- a/subcommands/genericgame/addplayer.js
+++ b/subcommands/genericgame/addplayer.js
@@ -46,7 +46,7 @@ class AddPlayer {
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
         await interaction.editReply(
-            await Formatter.createGameStatusReply(gameData, interaction.guild, {
+            await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
                 content: `Added ${newPlayer} to the game at position ${newOrder + 1}`
             })
         )

--- a/subcommands/genericgame/addscore.js
+++ b/subcommands/genericgame/addscore.js
@@ -36,7 +36,7 @@ class AddScore {
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
         await interaction.editReply(
-            await Formatter.createGameStatusReply(gameData, interaction.guild, {
+            await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
                 content: `Set ${targetPlayer}'s score to: ${score}`
             })
         )

--- a/subcommands/genericgame/firstplayer.js
+++ b/subcommands/genericgame/firstplayer.js
@@ -52,7 +52,7 @@ class FirstPlayer {
       );
 
       await interaction.reply(
-        await Formatter.createGameStatusReply(gameData, interaction.guild, {
+        await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
           content: `${newFirstPlayer} is now the first player.`
         })
       );

--- a/subcommands/genericgame/newgame.js
+++ b/subcommands/genericgame/newgame.js
@@ -52,7 +52,7 @@ class NewGame {
             await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
             
             await interaction.reply(
-                await Formatter.createGameStatusReply(gameData, interaction.guild, {
+                await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
                     content: content
                 })
             )

--- a/subcommands/genericgame/newgameplus.js
+++ b/subcommands/genericgame/newgameplus.js
@@ -141,7 +141,7 @@ class NewGame {
 
       // Then send the game status
       await interaction.followUp(
-        await Formatter.createGameStatusReply(gameData, interaction.guild, {
+        await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
           content: content
         })
       );

--- a/subcommands/genericgame/removeplayer.js
+++ b/subcommands/genericgame/removeplayer.js
@@ -52,7 +52,7 @@ class RemovePlayer {
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
         await interaction.editReply(
-            await Formatter.createGameStatusReply(gameData, interaction.guild, {
+            await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
                 content: `Removed ${playerToRemove} from the game and discarded their cards`
             })
         )

--- a/subcommands/genericgame/reverse.js
+++ b/subcommands/genericgame/reverse.js
@@ -23,7 +23,7 @@ class Reverse {
     await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
     
     await interaction.editReply(
-      await Formatter.createGameStatusReply(gameData, interaction.guild, {
+      await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, {
         content: `Turn order has been ${gameData.reverseOrder ? 'reversed' : 'restored to normal'}`
       })
     )

--- a/subcommands/genericgame/status.js
+++ b/subcommands/genericgame/status.js
@@ -21,7 +21,7 @@ class Status {
         const secretTokensEmbed = player ? await Formatter.playerSecretTokens(gameData, player) : null
 
         await interaction.editReply(
-            await Formatter.createGameStatusReply(gameData, interaction.guild)
+            await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id)
         );
 
         // If the player has secret tokens, send them in an ephemeral followup


### PR DESCRIPTION
Previously, the game status display would hide all secret token counts with a '?' regardless of who was viewing.

This change modifies the `GameFormatter.GameStatusV2` function to display the bot's own secret token count if the player being rendered is the bot itself. Other players' secret tokens remain hidden from the bot and other players in the main status.

To achieve this:
- `client.user.id` is now passed down from command handlers through `createGameStatusReply` to `GameStatusV2`.
- `GameStatusV2` uses this ID to conditionally display the token count for the bot.

The `/tokens check` command already provided a way for you (including the bot) to see your own specific secret token counts ephemerally, and its behavior remains unchanged and correct.