### PR TITLE
Add /cards hand discardall subcommand

### DIFF
--- a/slashcommands/genericgame/cards.js
+++ b/slashcommands/genericgame/cards.js
@@ -8,6 +8,7 @@ const Check = require('../../subcommands/cards/check')
 const Configure = require('../../subcommands/cards/configuredeck')
 const Deal = require('../../subcommands/cards/deal')
 const Discard = require(`../../subcommands/cards/discard`)
+const DiscardAll = require('../../subcommands/cards/discardall')
 const DraftDeal = require(`../../subcommands/cards/draftdeal`)
 const DraftPass = require(`../../subcommands/cards/draftpass`)
 const DraftTake = require(`../../subcommands/cards/drafttake`)
@@ -139,6 +140,11 @@ class Cards extends SlashCommand {
                         .setName("discard")
                         .setDescription("discard a card (not shown to everyone)")
                         .addStringOption(option => option.setName('card').setDescription('Card to discard').setAutocomplete(true).setRequired(true))
+                    )
+                .addSubcommand(subcommand =>
+                    subcommand
+                        .setName("discardall")
+                        .setDescription("Discards all cards from your hand.")
                     ) 
                 .addSubcommand(subcommand =>
                     subcommand
@@ -311,6 +317,9 @@ class Cards extends SlashCommand {
                     switch (interaction.options.getSubcommand()) {
                         case "discard":
                             await Discard.execute(interaction, this.client)
+                            break
+                        case "discardall":
+                            await DiscardAll.execute(interaction, this.client)
                             break
                         case "show":
                             await Show.execute(interaction, this.client)

--- a/subcommands/cards/discardall.js
+++ b/subcommands/cards/discardall.js
@@ -1,0 +1,84 @@
+const { SlashCommandBuilder } = require('discord.js');
+const GameHelper = require('../../modules/GlobalGameHelper');
+const Formatter = require('../../modules/GameFormatter');
+const { find, findIndex } = require('lodash');
+
+class DiscardAll {
+  constructor() {
+    this.data = new SlashCommandBuilder()
+      .setName('discardall')
+      .setDescription('Discards all cards from your hand.');
+  }
+
+  async execute(interaction, client) {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      let gameData = await GameHelper.getGameData(client, interaction);
+
+      if (gameData.isdeleted) {
+        await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true });
+        return;
+      }
+
+      let player = find(gameData.players, { userId: interaction.user.id });
+
+      if (!player) {
+        await interaction.editReply({ content: "Something went wrong, I couldn't find you in the game.", ephemeral: true });
+        return;
+      }
+
+      const playerHand = player.hands.main;
+
+      if (!playerHand || playerHand.length === 0) {
+        await interaction.editReply({ content: "Your hand is already empty.", ephemeral: true });
+        return;
+      }
+
+      const discardedCount = playerHand.length;
+
+      for (const card of playerHand) {
+        const deck = find(gameData.decks, { name: card.origin });
+        if (deck) {
+          if (!deck.piles.discard) { // Ensure discard pile exists
+            deck.piles.discard = { cards: [] };
+          }
+          deck.piles.discard.cards.push(card);
+        }
+        // If deck is not found, card effectively disappears, which is acceptable for discard.
+      }
+
+      player.hands.main = [];
+
+      await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
+
+      // Send public confirmation (edit the deferred reply)
+      await interaction.editReply(
+        await Formatter.createGameStatusReply(gameData, interaction.guild, {
+          content: `${interaction.member.displayName} has discarded all ${discardedCount} cards from their hand.`
+        })
+      );
+
+      // Send ephemeral follow-up to the user who initiated the command
+      await interaction.followUp({
+        content: `You have discarded all ${discardedCount} cards from your hand. Your hand is now empty.`,
+        ephemeral: true
+      });
+
+    } catch (e) {
+      console.error(e);
+      // Ensure a reply is sent even if an error occurs
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: "An error occurred while trying to discard all cards. Check the logs.", ephemeral: true }).catch(() => {}); // catch potential error if interaction is already gone
+      } else {
+        await interaction.reply({ content: "An error occurred while trying to discard all cards. Check the logs.", ephemeral: true }).catch(() => {});
+      }
+      // It's good practice to log the error to your logging system (e.g., client.logger.error(e) if available)
+      if (client.logger) {
+        client.logger.log(e, 'error');
+      }
+    }
+  }
+}
+
+module.exports = new DiscardAll();

--- a/subcommands/cards/help.js
+++ b/subcommands/cards/help.js
@@ -26,6 +26,7 @@ class Help {
 
         const hand_and_game_commands_header = `\n**Hand & Game Commands:**`;
         const hand_and_game_commands_content = `• **/cards hand discard** - Puts a card from your hand into the deck's discard pile. Card is not show to other players.
+• **/cards hand discardall** - Discards all cards from your hand into their respective deck's discard piles. Not shown to other players.
 • **/cards hand play** - Plays a card from your hand into the deck's discard pile. Card is shows to everyone as played.
 • **/cards hand return** - Returns a card to the top of the draw pile. Not shown to others. *Not Avaialbe Yet*
 • **/cards hand reveal** - Reveals a card in your hand to other players, but card stays in your hand. *Not Avaialbe Yet*

--- a/subcommands/cards/help.js
+++ b/subcommands/cards/help.js
@@ -26,7 +26,7 @@ class Help {
 
         const hand_and_game_commands_header = `\n**Hand & Game Commands:**`;
         const hand_and_game_commands_content = `• **/cards hand discard** - Puts a card from your hand into the deck's discard pile. Card is not show to other players.
-• **/cards hand discardall** - Discards all cards from your hand into their respective deck's discard piles. Not shown to other players.
+• **/cards hand discardall** - Discards all cards from your hand into their respective deck's discard piles.
 • **/cards hand play** - Plays a card from your hand into the deck's discard pile. Card is shows to everyone as played.
 • **/cards hand return** - Returns a card to the top of the draw pile. Not shown to others. *Not Avaialbe Yet*
 • **/cards hand reveal** - Reveals a card in your hand to other players, but card stays in your hand. *Not Avaialbe Yet*


### PR DESCRIPTION
This commit introduces a new subcommand `discardall` to the `/cards hand` command group.

You can now use `/cards hand discardall` to discard all cards currently in your hand without needing to select them individually. The command moves all cards from the player's hand to their respective deck's discard piles and notifies the channel and the player accordingly.