### PR TITLE
feat: Add totals section to game status display

### DIFF
--- a/modules/GameFormatter.js
+++ b/modules/GameFormatter.js
@@ -210,7 +210,8 @@ class GameFormatter {
 
     const hasTokens = gameData.tokens && gameData.tokens.length > 0;
     const canvasWidth = hasTokens ? 1200 : 800;
-    const canvas = createCanvas(canvasWidth, 100 + 35 * (gameData.players.length + 2)); // +2 for divider and totals row.
+    const additionalRows = 2; // Divider and totals row
+    const canvas = createCanvas(canvasWidth, 100 + 35 * (gameData.players.length + additionalRows));
     let ctx = canvas.getContext("2d");
     ctx.textDrawingMode = "glyph";
 

--- a/modules/GameFormatter.js
+++ b/modules/GameFormatter.js
@@ -187,7 +187,16 @@ class GameFormatter {
     const totalsRowData = ['Totals', ''];
     if (gameData.tokens && gameData.tokens.length > 0) {
       gameData.tokens.forEach(token => {
-        totalsRowData.push(tokenTotals[token.id].toString());
+        const currentTotal = tokenTotals[token.id];
+        let displayValue;
+        if (currentTotal === '?') {
+          displayValue = '?';
+        } else if (token.cap && typeof token.cap === 'number' && isFinite(token.cap)) {
+          displayValue = `${currentTotal} (of ${token.cap})`;
+        } else {
+          displayValue = currentTotal.toString();
+        }
+        totalsRowData.push(displayValue);
       });
     }
     const displayTotalCards = anyPlayerCardCountIsHidden ? '?' : totalCards.toString();


### PR DESCRIPTION
Updates the game status table generated by `GameFormatter.GameStatusV2` to include a divider and a totals row.

The totals row provides aggregate counts for:
- Cards in hand across all players. Displays '?' if any player's hand size is hidden.
- Each token type across all players. Displays '?' for secret tokens that do not have a defined cap.

Additionally, the divider row was changed from empty strings to hyphens as a speculative fix for a `canvas-table` rendering error observed during testing. The core logic for totals calculation was verified via simulated test data.