### PR TITLE
Refactor: Move /games addscore to /players score

### DIFF
--- a/slashcommands/genericgame/game.js
+++ b/slashcommands/genericgame/game.js
@@ -11,7 +11,6 @@ const Status = require(`../../subcommands/genericgame/status`)
 const Winner = require(`../../subcommands/genericgame/winner`)
 const Test = require(`../../subcommands/genericgame/test`)
 const Reverse = require(`../../subcommands/genericgame/reverse`)
-const AddScore = require(`../../subcommands/genericgame/addscore`)
 const Help = require('../../subcommands/genericgame/help.js')
 
 class Game extends SlashCommand {
@@ -151,21 +150,6 @@ class Game extends SlashCommand {
                         .setRequired(true)
                     )
                 )
-            .addSubcommand(subcommand =>
-                subcommand
-                    .setName("addscore")
-                    .setDescription("Add a score for a player")
-                    .addUserOption(option => 
-                        option.setName("player")
-                        .setDescription("The player to set the score for")
-                        .setRequired(true)
-                    )
-                    .addStringOption(option =>
-                        option.setName("score")
-                        .setDescription("The score to set")
-                        .setRequired(true)
-                    )
-            )
                 /*
             .addSubcommand(subcommand =>
                 subcommand
@@ -214,9 +198,6 @@ class Game extends SlashCommand {
                     break
                 case "removeimage":
                     await RemoveImage.execute(interaction, this.client)
-                    break
-                case "addscore":
-                    await AddScore.execute(interaction, this.client)
                     break
                 case "help":
                     await Help.execute(interaction, this.client)

--- a/slashcommands/players/players.js
+++ b/slashcommands/players/players.js
@@ -4,6 +4,7 @@ const Add = require(`../../subcommands/players/add`)
 const Remove = require(`../../subcommands/players/remove`)
 const First = require(`../../subcommands/players/first`)
 const Color = require(`../../subcommands/players/color`)
+const Score = require('../../subcommands/players/score.js') // Added import for Score
 const Help = require('../../subcommands/players/help.js')
 
 class Players extends SlashCommand {
@@ -69,6 +70,21 @@ class Players extends SlashCommand {
                         .setRequired(true)
                     )
             )
+            .addSubcommand(subcommand => // Added subcommand definition for score
+                subcommand
+                    .setName("score")
+                    .setDescription("Set a player's score. Defaults to the command user if no player is specified.")
+                    .addStringOption(option =>
+                        option.setName("score")
+                        .setDescription("The score to set")
+                        .setRequired(true)
+                    )
+                    .addUserOption(option =>
+                        option.setName("player")
+                        .setDescription("The player to set the score for (optional, defaults to you)")
+                        .setRequired(false)
+                    )
+            )
     }
 
     async execute(interaction) {
@@ -84,7 +100,10 @@ class Players extends SlashCommand {
                     await First.execute(interaction, this.client)
                     break
                 case "color":
-                    await Color.execute(interaction, this.client) // Assuming Color will be the class/object for the subcommand
+                    await Color.execute(interaction, this.client)
+                    break
+                case "score": // Added case for score
+                    await Score.execute(interaction, this.client)
                     break
                 case "help":
                     await Help.execute(interaction, this.client)

--- a/subcommands/genericgame/help.js
+++ b/subcommands/genericgame/help.js
@@ -30,7 +30,6 @@ Here's a list of commands to get you started. Don't worry, they're super easy to
 *   **/game removeimage** 🚫🖼️ - Changed your mind? Removes an image from the game. Poof! It's gone.
 *   **/game addlink** 🔗 - Sharing is caring! Adds a link to the game. Let's see those cool links!
 *   **/game removelink** 🚫🔗 - Oops, wrong link? Removes a link from the game. No problemo!
-*   **/game addscore** 💯 - Keep track of those points! Adds or updates a player's score. Aim for the high score!
 *   **/game test** 🧪 - Just checking things out! For testing purposes. Nothing to see here, folks! 😉`;
 
         await interaction.followUp({

--- a/subcommands/players/help.js
+++ b/subcommands/players/help.js
@@ -15,6 +15,7 @@ Here's a list of commands to get you started. They're super easy to use! 😉
         const commands_chunk_1 = `*   **/players add** 🙋‍♀️ - The more the merrier! Adds a player to the game. Welcome aboard!
 *   **/players remove** 🚶‍♂️ - Need to make some room? Removes a player from the game. See ya later, alligator!
 *   **/players first** 🥇 - Who's the lucky one? Sets the first player. May the odds be ever in your favor!
+*   **/players score <score> [player]** 💯 - Set a player's score. If no player is mentioned, it sets your score.
 *   **/players color <player> <color>** 🎨 - Feeling colorful? Sets a display color for a player (e.g., #FF0000 or "red").`;
 
         await interaction.followUp({

--- a/subcommands/players/score.js
+++ b/subcommands/players/score.js
@@ -17,7 +17,7 @@ class AddScore {
             return
         }
 
-        const targetPlayer = interaction.options.getUser('player')
+        const targetPlayer = interaction.options.getUser('player') || interaction.user
         const score = interaction.options.getString('score')
         
         // Find the player in the game
@@ -43,4 +43,4 @@ class AddScore {
     }
 }
 
-module.exports = new AddScore() 
+module.exports = new AddScore()


### PR DESCRIPTION
I've moved the addscore command from `/games addscore <player> <score>` to `/players score <score> [player]`.

Key changes:
- The `player` argument in the new `/players score` command is now optional. If you don't provide it, the command defaults to you.
- The old `/games addscore` command has been removed.
- I've updated the help documentation for both `/games` and `/players` command groups to reflect these changes.