### PR TITLE
feat: Add /cards playarea clearall command

### DIFF
--- a/slashcommands/genericgame/cards.js
+++ b/slashcommands/genericgame/cards.js
@@ -35,6 +35,7 @@ const PlayAreaPick = require('../../subcommands/cards/playareapick') // Restorin
 const PlayAreaTake = require('../../subcommands/cards/playareatake') // Restoring
 const PlayAreaGive = require('../../subcommands/cards/playareagive') // Restoring
 const PlayAreaClearAll = require('../../subcommands/cards/playareaclearall')
+const Burn = require('../../subcommands/cards/burn')
 
 class Cards extends SlashCommand {
     constructor(client){
@@ -129,6 +130,20 @@ class Cards extends SlashCommand {
                     .setName("pick")
                     .setDescription("Pick a card (or cards) from the discard pile")
                     .addStringOption(option => option.setName('deck').setDescription('Deck to pick from').setAutocomplete(true))
+            )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName("burn")
+                    .setDescription("Move a specified number of cards from the top of a deck to the discard pile without revealing them.")
+                    .addIntegerOption(option =>
+                        option.setName('count')
+                              .setDescription('Number of cards to burn.')
+                              .setRequired(true)
+                              .setMinValue(1))
+                    .addStringOption(option =>
+                        option.setName('deck')
+                              .setDescription('Deck to burn from.')
+                              .setAutocomplete(true))
             );
         });
         this.data.addSubcommandGroup(group =>
@@ -318,6 +333,9 @@ class Cards extends SlashCommand {
                             break
                         case "shuffle":
                             await Shuffle.execute(interaction, this.client)
+                            break
+                        case "burn":
+                            await Burn.execute(interaction, this.client)
                             break
                         default:
                             await interaction.reply({ content: "Command not fully written yet :(", ephemeral: true })

--- a/slashcommands/genericgame/cards.js
+++ b/slashcommands/genericgame/cards.js
@@ -34,6 +34,7 @@ const PlayAreaDiscard = require('../../subcommands/cards/playareadiscard') // Re
 const PlayAreaPick = require('../../subcommands/cards/playareapick') // Restoring
 const PlayAreaTake = require('../../subcommands/cards/playareatake') // Restoring
 const PlayAreaGive = require('../../subcommands/cards/playareagive') // Restoring
+const PlayAreaClearAll = require('../../subcommands/cards/playareaclearall')
 
 class Cards extends SlashCommand {
     constructor(client){
@@ -272,6 +273,11 @@ class Cards extends SlashCommand {
                     .setDescription("Give one or more cards from your play area to another player.") // Updated description
                     .addUserOption(option => option.setName('target').setDescription('The player to give cards to').setRequired(true))
             )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName("clearall")
+                    .setDescription("Move all cards from all play areas to the discard pile(s).")
+            )
         );
     }
 
@@ -373,6 +379,9 @@ class Cards extends SlashCommand {
                             break
                         case "give":
                             await PlayAreaGive.execute(interaction, this.client)
+                            break
+                        case "clearall":
+                            await PlayAreaClearAll.execute(interaction, this.client)
                             break
                         default:
                             await interaction.reply({ content: "Unknown playarea command.", ephemeral: true })

--- a/subcommands/cards/burn.js
+++ b/subcommands/cards/burn.js
@@ -1,0 +1,75 @@
+const GameHelper = require('../../modules/GlobalGameHelper');
+// No Formatter needed as we are not displaying card details
+
+class Burn {
+    async execute(interaction, client) {
+        if (interaction.isAutocomplete()) {
+            let gameData = await GameHelper.getGameData(client, interaction);
+            await GameHelper.getDeckAutocomplete(gameData, interaction);
+            return;
+        }
+
+        await interaction.deferReply();
+
+        let gameData = await GameHelper.getGameData(client, interaction);
+
+        if (gameData.isdeleted) {
+            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true });
+            return;
+        }
+
+        const inputDeck = interaction.options.getString('deck');
+        const deck = GameHelper.getSpecificDeck(gameData, inputDeck, interaction.user.id);
+
+        if (!deck) {
+            await interaction.editReply({ content: "Specified deck not found or no default deck available.", ephemeral: true });
+            return;
+        }
+
+        if (!deck.piles || !deck.piles.draw || deck.piles.draw.cards.length < 1) {
+            await interaction.editReply({ content: `The draw pile for ${deck.name} is empty.`, ephemeral: true });
+            return;
+        }
+
+        const countToBurn = interaction.options.getInteger('count');
+
+        if (countToBurn <= 0) {
+            await interaction.editReply({ content: "Number of cards to burn must be greater than 0.", ephemeral: true });
+            return;
+        }
+
+        let actualBurnedCount = 0;
+        for (let i = 0; i < countToBurn; i++) {
+            if (deck.piles.draw.cards.length > 0) {
+                const cardToBurn = deck.piles.draw.cards.shift();
+                if (!deck.piles.discard) { // Should exist, but good practice
+                    deck.piles.discard = { cards: [], viewable: true };
+                }
+                deck.piles.discard.cards.push(cardToBurn);
+                actualBurnedCount++;
+            } else {
+                // Ran out of cards in the draw pile
+                break;
+            }
+        }
+
+        if (actualBurnedCount === 0) {
+            // This case should ideally be caught by the initial draw pile check, but as a safeguard:
+            await interaction.editReply({ content: `No cards were burned. The draw pile for ${deck.name} might be empty.`, ephemeral: true });
+            return;
+        }
+
+        await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
+
+        let replyMessage = `Burned ${actualBurnedCount} card(s) from the top of ${deck.name}.`;
+        if (actualBurnedCount < countToBurn) {
+            replyMessage += ` (Requested ${countToBurn}, but only ${actualBurnedCount} were available in the draw pile.)`;
+        }
+
+        await interaction.editReply({
+            content: replyMessage
+        });
+    }
+}
+
+module.exports = new Burn();

--- a/subcommands/cards/playareaclearall.js
+++ b/subcommands/cards/playareaclearall.js
@@ -1,0 +1,61 @@
+const GameHelper = require('../../modules/GlobalGameHelper');
+const { find, cloneDeep } = require('lodash');
+
+module.exports = {
+    name: "playareaclearall",
+    async execute(interaction, client) {
+        try {
+            const gameData = await GameHelper.getGameData(client, interaction);
+
+            if (!gameData || gameData.isdeleted) {
+                await interaction.reply({ content: "There is no game active in this channel, or the game data is unavailable.", ephemeral: true });
+                return;
+            }
+
+            if (!gameData.players || gameData.players.length === 0) {
+                await interaction.reply({ content: "There are no players in the game to clear play areas for.", ephemeral: true });
+                return;
+            }
+
+            let cardsMovedCount = 0;
+            const updatedGameData = cloneDeep(gameData);
+
+            for (const player of updatedGameData.players) {
+                if (player.playArea && player.playArea.length > 0) {
+                    const cardsToMove = [...player.playArea]; // Iterate over a copy
+                    for (const card of cardsToMove) {
+                        const deck = find(updatedGameData.decks, { name: card.origin });
+                        if (deck) {
+                            if (!deck.piles.discard) {
+                                deck.piles.discard = { cards: [], viewable: true }; // Should exist based on defaultDeck, but good practice
+                            }
+                            deck.piles.discard.cards.push(card);
+                            // Remove card from playArea by id
+                            const cardIndex = player.playArea.findIndex(c => c.id === card.id);
+                            if (cardIndex > -1) {
+                                player.playArea.splice(cardIndex, 1);
+                                cardsMovedCount++;
+                            }
+                        } else {
+                            // This case should ideally not happen if card.origin is always valid
+                            console.warn(`Could not find origin deck "${card.origin}" for card "${card.name}" in player ${player.userId}'s play area.`);
+                            // Decide if we want to notify user or just log
+                        }
+                    }
+                }
+            }
+
+            if (cardsMovedCount === 0) {
+                await interaction.reply({ content: "All player play areas were already empty. No cards were moved.", ephemeral: false });
+                return;
+            }
+
+            await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, updatedGameData);
+            await interaction.reply({ content: `Successfully moved ${cardsMovedCount} card(s) from all player play areas to their respective discard pile(s).`, ephemeral: false });
+
+        } catch (e) {
+            console.error("Error in /cards playarea clearall:", e);
+            await interaction.reply({ content: "An error occurred while trying to clear all play areas. Please try again later.", ephemeral: true });
+        }
+    }
+};

--- a/subcommands/cards/recall.js
+++ b/subcommands/cards/recall.js
@@ -31,11 +31,26 @@ class Recall {
         } 
 
         gameData.players.forEach(player => {
-            remove(player.hands.main, card => card.origin === deck.name)
-            if (player.hands.draft){
-                remove(player.hands.draft, card => card.origin === deck.name)
+            // Helper function to safely remove cards by origin
+            const removeCardsFromLocation = (locationArray) => {
+                if (Array.isArray(locationArray)) {
+                    remove(locationArray, card => card.origin === deck.name);
+                }
+            };
+
+            if (player.hands) {
+                removeCardsFromLocation(player.hands.main);
+                removeCardsFromLocation(player.hands.draft);
+                removeCardsFromLocation(player.hands.played);
+                removeCardsFromLocation(player.hands.passed);
+                removeCardsFromLocation(player.hands.received);
+                removeCardsFromLocation(player.hands.simultaneous);
             }
-        })
+
+            if (player.playArea) { // playArea is directly on player object
+                removeCardsFromLocation(player.playArea);
+            }
+        });
 
         deck.piles.discard.cards = []
         deck.piles.draw.cards = cloneDeep(shuffle(deck.allCards))


### PR DESCRIPTION
This commit introduces a new slash command `/cards playarea clearall`. This command allows users to move all cards from every player's play area to their respective discard piles.

- Created `subcommands/cards/playareaclearall.js` to handle the command logic.
- Updated `slashcommands/genericgame/cards.js` to register and route the new subcommand.