### PR TITLE
First pass on what a command that peeks into the deck might look like.

### DIFF
--- a/slashcommands/genericgame/cards.js
+++ b/slashcommands/genericgame/cards.js
@@ -36,6 +36,7 @@ const PlayAreaTake = require('../../subcommands/cards/playareatake') // Restorin
 const PlayAreaGive = require('../../subcommands/cards/playareagive') // Restoring
 const PlayAreaClearAll = require('../../subcommands/cards/playareaclearall')
 const Burn = require('../../subcommands/cards/burn')
+const DeckPeek = require('../../subcommands/cards/deckpeek')
 
 class Cards extends SlashCommand {
     constructor(client){
@@ -100,6 +101,13 @@ class Cards extends SlashCommand {
                     .setDescription("Flip the top card of the deck")
                     .addStringOption(option => option.setName('deck').setDescription('Deck to flip from').setAutocomplete(true))
                 ) 
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName("peek")
+                    .setDescription("Privately peek at the top card (or a card deeper in the deck) without removing it.")
+                    .addIntegerOption(option => option.setName('depth').setDescription('How deep to peek (1 = top card)').setRequired(false).setMinValue(1))
+                    .addStringOption(option => option.setName('deck').setDescription('Deck to peek at').setAutocomplete(true).setRequired(true))
+            )
             .addSubcommand(subcommand =>
                 subcommand
                     .setName("deal")
@@ -336,6 +344,9 @@ class Cards extends SlashCommand {
                             break
                         case "burn":
                             await Burn.execute(interaction, this.client)
+                            break
+                        case "peek":
+                            await DeckPeek.execute(interaction, this.client)
                             break
                         default:
                             await interaction.reply({ content: "Command not fully written yet :(", ephemeral: true })

--- a/subcommands/cards/deckpeek.js
+++ b/subcommands/cards/deckpeek.js
@@ -1,0 +1,57 @@
+const GameDB = require('../../db/anygame.js')
+
+module.exports = {
+    async execute(interaction, client) {
+        if (interaction.isAutocomplete()) {
+            let gameData = await GameHelper.getGameData(client, interaction)
+            await GameHelper.getDeckAutocomplete(gameData, interaction)
+        } else {
+            try {
+                await interaction.deferReply({ ephemeral: true })
+
+                const deckName = interaction.options.getString('deck');
+                let depth = interaction.options.getInteger('depth') ?? 1;
+                if (!deckName) {
+                    await interaction.editReply({ content: 'You must specify a deck to peek at.', ephemeral: true });
+                    return;
+                }
+                if (depth < 1) {
+                    await interaction.editReply({ content: 'Depth must be at least 1.', ephemeral: true });
+                    return;
+                }
+                // Fetch the deck from the DB
+                const deckData = await GameDB.getDeck(interaction.channelId, deckName);
+                if (!deckData || !Array.isArray(deckData.cards) || deckData.cards.length === 0) {
+                    await interaction.editReply({ content: `Deck "${deckName}" is empty or not set up correctly.`, ephemeral: true });
+                    return;
+                }
+                if (depth > deckData.cards.length) {
+                    await interaction.editReply({ content: `Deck "${deckName}" only has ${deckData.cards.length} card(s). Cannot peek at position ${depth}.`, ephemeral: true });
+                    return;
+                }
+                const theCard = deckData.cards[depth - 1];
+
+                await interaction.editReply(
+                    await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id,
+                        { 
+                            content: `${interaction.member.displayName} peeked at a card from deck ${deck.name} at depth ${depth}`,
+                            ephemeral: false
+                        }
+                    )
+                );
+                await interaction.followUp({ 
+                    content: `You drew:`, 
+                    embeds: [Formatter.oneCard(theCard)],
+                    ephemeral: true
+                })
+            } catch (e) {
+                if (interaction && interaction.reply) {
+                    await interaction.reply({ content: 'An error occurred while peeking at the deck.', ephemeral: true });
+                }
+                if (client && client.logger) {
+                    client.logger.log(e, 'error');
+                }
+            }
+        }
+    }
+};


### PR DESCRIPTION
This is mostly based on the Draw command as reference. I'm not sure how to test this short of deploying it, but if it looks good to you we can give it a shot and see what happens!.

The goal of the peek command is to allow looking at cards in the deck without affecting the deck. In Spectral, we could use this by setting an "index" of all 16 cards and have players peek at the card they are searching. We can then make a shuffle a spectral deck once and we should be good to run the whole game.