### PR TITLE
feat: Add /cards deck remove command

### DIFF
--- a/slashcommands/genericgame/cards.js
+++ b/slashcommands/genericgame/cards.js
@@ -37,6 +37,7 @@ const PlayAreaGive = require('../../subcommands/cards/playareagive') // Restorin
 const PlayAreaClearAll = require('../../subcommands/cards/playareaclearall')
 const Burn = require('../../subcommands/cards/burn')
 const DeckPeek = require('../../subcommands/cards/deckpeek')
+const DeckRemove = require('../../subcommands/cards/deckremove')
 
 class Cards extends SlashCommand {
     constructor(client){
@@ -152,6 +153,13 @@ class Cards extends SlashCommand {
                         option.setName('deck')
                               .setDescription('Deck to burn from.')
                               .setAutocomplete(true))
+            )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName("remove")
+                    .setDescription("Remove a deck from the game entirely.")
+                    .addStringOption(option => option.setName('deckname').setDescription('Name of the deck to remove').setRequired(true).setAutocomplete(true))
+                    .addStringOption(option => option.setName('confirm').setDescription("Type 'delete' to confirm").setRequired(true))
             );
         });
         this.data.addSubcommandGroup(group =>
@@ -347,6 +355,9 @@ class Cards extends SlashCommand {
                             break
                         case "peek":
                             await DeckPeek.execute(interaction, this.client)
+                            break
+                        case "remove":
+                            await DeckRemove.execute(interaction, this.client)
                             break
                         default:
                             await interaction.reply({ content: "Command not fully written yet :(", ephemeral: true })

--- a/subcommands/cards/deckremove.js
+++ b/subcommands/cards/deckremove.js
@@ -1,0 +1,93 @@
+const GameHelper = require('../../modules/GlobalGameHelper')
+const GameDB = require('../../db/anygame.js')
+const { find, remove, cloneDeep, shuffle } = require('lodash')
+const Formatter = require('../../modules/GameFormatter')
+
+class DeckRemove {
+    async execute(interaction, client) {
+        if (interaction.isAutocomplete()) {
+            let gameData = await GameHelper.getGameData(client, interaction)
+            if (gameData.isdeleted || gameData.decks.length < 1){
+                await interaction.respond([])
+                return
+            }
+            await interaction.respond(gameData.decks.map(d => ({name: d.name, value: d.name})))
+            return
+        }
+
+        if (interaction.options.getString('confirm') !== 'delete') {
+            await interaction.reply({ content: `Deck not deleted. You must confirm by typing 'delete' in the confirm option.`, ephemeral: true })
+            return
+        }
+
+        await interaction.deferReply()
+
+        let gameData = await GameHelper.getGameData(client, interaction)
+
+        if (gameData.isdeleted) {
+            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
+            return
+        }
+
+        const inputDeck = interaction.options.getString('deckname')
+        const deck = find(gameData.decks, {name: inputDeck})
+        if (!deck){
+            await interaction.editReply({ content: `Could not find a deck named "${inputDeck}".`, ephemeral: true })
+            return
+        }
+
+        // Recall logic first
+        gameData.players.forEach(player => {
+            const removeCardsFromLocation = (locationArray) => {
+                if (Array.isArray(locationArray)) {
+                    remove(locationArray, card => card.origin === deck.name);
+                }
+            };
+
+            if (player.hands) {
+                removeCardsFromLocation(player.hands.main);
+                removeCardsFromLocation(player.hands.draft);
+                removeCardsFromLocation(player.hands.played);
+                removeCardsFromLocation(player.hands.passed);
+                removeCardsFromLocation(player.hands.received);
+                removeCardsFromLocation(player.hands.simultaneous);
+            }
+
+            if (player.playArea) {
+                removeCardsFromLocation(player.playArea);
+            }
+        });
+
+        const deckName = deck.name;
+        // Now remove the deck
+        remove(gameData.decks, {name: deck.name});
+
+        // Record history
+        try {
+            const actorDisplayName = interaction.member?.displayName || interaction.user.username
+
+            GameHelper.recordMove(
+                gameData,
+                interaction.user,
+                GameDB.ACTION_CATEGORIES.CARD,
+                GameDB.ACTION_TYPES.DELETE,
+                `${actorDisplayName} removed the deck "${deckName}" from the game.`,
+                {
+                    deckName: deckName,
+                    action: "deck remove"
+                }
+            )
+        } catch (error) {
+            console.warn('Failed to record deck removal in history:', error)
+        }
+
+        await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
+        await interaction.editReply(
+            await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id,
+              { content: `Deck "${deckName}" has been removed.` }
+            )
+          );
+    }
+}
+
+module.exports = new DeckRemove()

--- a/subcommands/cards/deckremove.js
+++ b/subcommands/cards/deckremove.js
@@ -1,7 +1,7 @@
 const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
-const { find, remove, cloneDeep, shuffle } = require('lodash')
-const Formatter = require('../../modules/GameFormatter')
+const { find, remove } = require('lodash')
+const Formatter =require('../../modules/GameFormatter')
 
 class DeckRemove {
     async execute(interaction, client) {
@@ -37,13 +37,13 @@ class DeckRemove {
         }
 
         // Recall logic first
-        gameData.players.forEach(player => {
-            const removeCardsFromLocation = (locationArray) => {
-                if (Array.isArray(locationArray)) {
-                    remove(locationArray, card => card.origin === deck.name);
-                }
-            };
+        const removeCardsFromLocation = (locationArray) => {
+            if (Array.isArray(locationArray)) {
+                remove(locationArray, card => card.origin === deck.name);
+            }
+        };
 
+        gameData.players.forEach(player => {
             if (player.hands) {
                 removeCardsFromLocation(player.hands.main);
                 removeCardsFromLocation(player.hands.draft);

--- a/subcommands/cards/help.js
+++ b/subcommands/cards/help.js
@@ -15,6 +15,7 @@ class Help {
         const deck_commands_header = `\n**Deck Commands:**`;
         const deck_commands_content = `• **/cards deck new** - Create a new deck of cards in the channel. All cards will be shuffled into a "Draw" pile. Of note there needs to be a /game started
 • **/cards deck draw** - Draw a card from a deck in the channel (if no deck is specified, will draw from first created in channel)
+• **/cards deck remove** - Remove a deck from the game entirely. This cannot be undone.
 • **/cards deck configure** - To add special rules to a deck. *Not Avaialbe Yet*
 • **/cards deck flipcard** - Flips and shows the top card of the deck. It is then added to the discard pile
 • **/cards deck shuffle** - Shuffle the draw and discard piles together into a new draw pile. *Not Avaialbe Yet*`;


### PR DESCRIPTION
## Release Notes - Deck Management Enhancement 🃏
**TL;DR:** You can now permanently remove decks from your games with /cards deck remove - use with caution!

### New Features
🗑️ Deck Removal Command - Added `/cards deck remove` to completely remove a deck from your game. This is a permanent action that:

- Removes the deck entirely from the game
- Automatically recalls all cards from that deck back from player hands and play areas
- Requires typing "delete" to confirm (no accidents!)
- Records the action in game history for transparency

### Improvements
_Enhanced Help Documentation_ - Updated `/cards help` to include the new remove command with clear warnings about its permanent nature.
### Usage

Use `/cards deck remove` when you need to clean up test decks or remove decks that are no longer needed. Remember: this cannot be undone, so double-check before confirming!

---
As always, the bot continues to track all actions in game history, so your game's story remains complete even when decks are removed.