### PR TITLE
Add Arcs action card decks

### DIFF
--- a/db/anygame.js
+++ b/db/anygame.js
@@ -50,6 +50,7 @@ const rebirth = require('./decks/rebirth');
 const candylandCards = require('./decks/candyland');
 const botswanaCards = require('./decks/botswana');
 const {mollyVice, mollyLoyalty, mollyMinor, mollyMajor, mollyItem} = require('./decks/mollyhouse');
+const { arcsActionBase, arcsActionFull } = require('./decks/arcs');
 
 class GameDatabase {
     
@@ -152,6 +153,8 @@ class GameDatabase {
         [ "Molly House - Minor Indictment", "molly-minor" ],
         [ "Molly House - Major Indictment", "molly-major" ],
         [ "Molly House - Items", "molly-item" ],
+        [ "Arcs Action Cards (2-3 Players)", "arcs-2-3" ],
+        [ "Arcs Action Cards (4 Players)", "arcs-4" ],
     ]
 
     defaultGameData = {
@@ -440,6 +443,10 @@ class GameDatabase {
                 return this.createCardFromObjList(deckName, "B", mollyMajor);
             case "molly-item":
                 return this.createCardFromObjList(deckName, "B", mollyItem);
+            case "arcs-2-3":
+                return this.createCardFromObjList(deckName, "A", arcsActionBase);
+            case "arcs-4":
+                return this.createCardFromObjList(deckName, "A", arcsActionFull);
             default:
                 return []
         }

--- a/db/decks/arcs.js
+++ b/db/decks/arcs.js
@@ -1,0 +1,36 @@
+const SUITS = [
+  { name: "Construction", index: 0, actions: "Build or Repair" },
+  { name: "Administration", index: 1, actions: "Tax, Repair, or Influence" },
+  { name: "Aggression", index: 2, actions: "Battle, Move, or Secure" },
+  { name: "Mobilization", index: 3, actions: "Move or Influence" },
+];
+const AMBITIONS = { 2: "Tycoon", 3: "Tyrant", 4: "Warlord", 5: "Keeper", 6: "Empath" };
+
+function buildCard(suit, number) {
+  const ambitionText =
+    number === 1
+      ? "No ambition."
+      : number === 7
+        ? "Declares any ambition."
+        : `Declares ${AMBITIONS[number]} ambition.`;
+  return {
+    name: `${suit.name} ${number}`,
+    value: String(number),
+    suit: suit.name,
+    type: "",
+    description: `${suit.actions}. ${ambitionText}`,
+    url: `https://furtivespy.com/images/arcs/arcs_${suit.index}_${number - 1}.png`,
+  };
+}
+
+const arcsActionBase = [];
+const arcsActionFull = [];
+for (const suit of SUITS) {
+  for (let n = 1; n <= 7; n++) {
+    const card = buildCard(suit, n);
+    arcsActionFull.push(card);
+    if (n >= 2 && n <= 6) arcsActionBase.push(card);
+  }
+}
+
+module.exports = { arcsActionBase, arcsActionFull };


### PR DESCRIPTION
## Summary
- Adds Arcs action card decks for 2-3 players (20 cards, numbers 2-6) and 4 players (28 cards, numbers 1-7), matching base rulebook setup.
- Wires both decks into the card picker as `arcs-2-3` and `arcs-4` with card images from furtivespy.com.
- Uses display format A so labels show as suit and number (e.g. `Aggression 6`) without duplicating the value prefix.

## Test plan
- [ ] Create a game and add deck "Arcs Action Cards (2-3 Players)" — confirm 20 cards, shuffle/draw/play work
- [ ] Create a game and add deck "Arcs Action Cards (4 Players)" — confirm 28 cards including 1s and 7s
- [ ] Verify card labels in hand/play area show as `Construction 3`, not `3: Construction 3`
- [ ] Spot-check card images load (e.g. Construction 4, Mobilization 7)


Made with [Cursor](https://cursor.com)