### PR TITLE
Add inbound and handler timing logs for slash commands.

### DIFF
--- a/DiscordBot.js
+++ b/DiscordBot.js
@@ -712,7 +712,15 @@ client.on("interactionCreate", async (interaction) => {
     const command = client.slashcommands.get(interaction.commandName);
 
     if (!command) return;
-    client.logger.log(`Slash Command ${interaction.commandName}`);
+
+    const startedAt = Date.now();
+    const inboundMs = startedAt - interaction.createdTimestamp;
+    const subcommand = interaction.options?.getSubcommand?.(false);
+    const label = subcommand
+      ? `${interaction.commandName} ${subcommand}`
+      : interaction.commandName;
+    const prefix = interaction.isAutocomplete() ? "Autocomplete" : "Slash";
+
     try {
       await command.execute(interaction);
     } catch (error) {
@@ -721,6 +729,12 @@ client.on("interactionCreate", async (interaction) => {
         content: "There was an error while executing this command!",
         ephemeral: true,
       });
+    } finally {
+      const durationMs = Date.now() - startedAt;
+      client.logger.log(
+        `${prefix} /${label} | inbound ${inboundMs}ms | handler ${durationMs}ms`,
+        "time"
+      );
     }
   } else if (interaction.isModalSubmit()) {
     try {

--- a/modules/Logger.js
+++ b/modules/Logger.js
@@ -25,8 +25,11 @@ class Logger {
       }
       case "ready": {
         return console.log(`${timestamp}: ${chalk.black.bgGreen(type.toUpperCase())} ${content}`);
-      } 
-      default: throw new TypeError("Logger type must be either warn, debug, log, ready, cmd or error.");
+      }
+      case "time": {
+        return console.log(`${timestamp}: ${chalk.black.bgCyan(type.toUpperCase())} ${content}`);
+      }
+      default: throw new TypeError("Logger type must be either warn, debug, log, ready, cmd, time or error.");
     } 
   }
   


### PR DESCRIPTION
Replace bare command logs with completion timing that shows Discord-to-handler latency and execute duration.