### PR TITLE
fix(workflows): fix semver build not running on PR merge to master

### DIFF
--- a/.github/workflows/_docker-build-push.yml
+++ b/.github/workflows/_docker-build-push.yml
@@ -1,0 +1,62 @@
+name: Docker Build and Push (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      semver_tag:
+        description: "Semver tag (e.g. v1.2.3). When provided, pushes semver + latest. Otherwise pushes commit SHA."
+        required: false
+        type: string
+        default: ""
+    secrets:
+      REGISTRY_USERNAME:
+        required: true
+      REGISTRY_TOKEN:
+        required: true
+
+env:
+  REGISTRY: gitea.willsullivan.dev
+  IMAGE_NAME: furtivespy/game-bot
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Resolve image tags
+        id: meta
+        run: |
+          if [[ -n "${{ inputs.semver_tag }}" ]]; then
+            {
+              echo "tags<<EOF"
+              echo "${REGISTRY}/${IMAGE_NAME}:${{ inputs.semver_tag }}"
+              echo "${REGISTRY}/${IMAGE_NAME}:latest"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            SHA="$(git rev-parse --short HEAD)"
+            echo "tags=${REGISTRY}/${IMAGE_NAME}:${SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -2,56 +2,12 @@ name: Build and Push Docker Image
 
 on:
   push:
-    tags:
-      - "v*"
-    branches-ignore:
-      - master
-      - main
-
-env:
-  REGISTRY: gitea.willsullivan.dev
-  IMAGE_NAME: furtivespy/game-bot
+    branches:
+      - "**"
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-
-      - name: Resolve image tags
-        id: meta
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-            {
-              echo "tags<<EOF"
-              echo "${REGISTRY}/${IMAGE_NAME}:${VERSION}"
-              echo "${REGISTRY}/${IMAGE_NAME}:latest"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          else
-            SHA="$(git rev-parse --short HEAD)"
-            echo "tags=${REGISTRY}/${IMAGE_NAME}:${SHA}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    uses: ./.github/workflows/_docker-build-push.yml
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 permissions: write-all
+
 on:
   pull_request:
     types: [closed]
@@ -9,6 +10,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -23,3 +26,13 @@ jobs:
           release_branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-push:
+    needs: release
+    if: needs.release.outputs.tag != ''
+    uses: ./.github/workflows/_docker-build-push.yml
+    with:
+      semver_tag: ${{ needs.release.outputs.tag }}
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

Two bugs prevented Docker images from being built and pushed correctly:

1. **`GITHUB_TOKEN` cannot trigger downstream workflows** — `release.yml` creates the semver tag using `GITHUB_TOKEN`, but GitHub intentionally blocks that from firing other workflow runs. The `tags: v*` trigger in `build-push.yml` never fired.

2. **`branches-ignore: master` blocked the SHA build on merge** — when a PR merged into master, the branch-push build was silently skipped.

## Fix

- Remove `branches-ignore` so all branches (including master) get a commit-SHA image push on every push.
- Add a `build-and-push` job directly inside `release.yml` chained via `needs: release`, reading the new tag from the step output. No cross-workflow trigger needed.
- Extract all shared Docker logic (buildx, login, tag resolution, build/push) into a reusable workflow (`_docker-build-push.yml`) to eliminate duplication. Both callers are now ~8 lines each.

## Result

| Event | Image tags pushed |
|---|---|
| Push to any branch | `<registry>/game-bot:<sha>` |
| PR merged to master | `<registry>/game-bot:<semver>`, `<registry>/game-bot:latest` |

Made with [Cursor](https://cursor.com)