### PR TITLE
perf(money): parallelize deferReply + getGameDataV2 in money subcommands

### DIFF
--- a/subcommands/money/check.js
+++ b/subcommands/money/check.js
@@ -5,17 +5,11 @@ const Formatter = require("../../modules/GameFormatter");
 
 class Check {
   async execute(interaction, client) {
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-    
-    let gameData = Object.assign(
-      {},
-      cloneDeep(GameDB.defaultGameData),
-      await client.getGameDataV2(
-        interaction.guildId,
-        "game",
-        interaction.channelId
-      )
-    );
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+      client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+    ]);
+    let gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
 
     if (gameData.isdeleted) {
       await interaction.editReply({

--- a/subcommands/money/pay.js
+++ b/subcommands/money/pay.js
@@ -6,17 +6,11 @@ const GameHelper = require("../../modules/GlobalGameHelper");
 
 class Pay {
   async execute(interaction, client) {
-    await interaction.deferReply();
-    
-    let gameData = Object.assign(
-      {},
-      cloneDeep(GameDB.defaultGameData),
-      await client.getGameDataV2(
-        interaction.guildId,
-        "game",
-        interaction.channelId
-      )
-    );
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply(),
+      client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+    ]);
+    let gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
 
     if (gameData.isdeleted) {
       await interaction.editReply({

--- a/subcommands/money/spend.js
+++ b/subcommands/money/spend.js
@@ -6,17 +6,11 @@ const GameHelper = require("../../modules/GlobalGameHelper");
 
 class Spend {
   async execute(interaction, client) {
-    await interaction.deferReply();
-    
-    let gameData = Object.assign(
-      {},
-      cloneDeep(GameDB.defaultGameData),
-      await client.getGameDataV2(
-        interaction.guildId,
-        "game",
-        interaction.channelId
-      )
-    );
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply(),
+      client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+    ]);
+    let gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
 
     if (gameData.isdeleted) {
       await interaction.editReply({

--- a/subcommands/money/take.js
+++ b/subcommands/money/take.js
@@ -6,17 +6,11 @@ const GameHelper = require("../../modules/GlobalGameHelper");
 
 class Take {
   async execute(interaction, client) {
-    await interaction.deferReply();
-    
-    let gameData = Object.assign(
-      {},
-      cloneDeep(GameDB.defaultGameData),
-      await client.getGameDataV2(
-        interaction.guildId,
-        "game",
-        interaction.channelId
-      )
-    );
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply(),
+      client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+    ]);
+    let gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
 
     if (gameData.isdeleted) {
       await interaction.editReply({


### PR DESCRIPTION
## Summary

- **What changed:** Updated 4 money subcommands (`check.js`, `pay.js`, `spend.js`, `take.js`) to run `interaction.deferReply()` and `client.getGameDataV2()` concurrently using `Promise.all()` instead of sequentially awaiting each call.
- **Optimization:** The Discord `deferReply` ACK and the database fetch were previously executed one after the other. They are independent operations, so running them in parallel eliminates the sequential wait. Each command now looks like:
  ```js
  const [, rawGameData] = await Promise.all([
    interaction.deferReply(),
    client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
  ]);
  ```
- **Expected savings:** ~200ms per invocation on write commands (pay, spend, take) and the ephemeral check command, since the DB round-trip now overlaps with the Discord network ACK instead of following it.

## Files changed

| File | Change |
|------|--------|
| `subcommands/money/check.js` | Parallel `deferReply` (ephemeral) + `getGameDataV2` |
| `subcommands/money/pay.js` | Parallel `deferReply` + `getGameDataV2` |
| `subcommands/money/spend.js` | Parallel `deferReply` + `getGameDataV2` |
| `subcommands/money/take.js` | Parallel `deferReply` + `getGameDataV2` |

## Files skipped

- **`help.js`** — Does not call `getGameDataV2`, so there is no concurrent work to parallelize.
- **`reveal.js`** — Has a different execution flow that doesn't follow the same `deferReply` → `getGameDataV2` pattern.

## Test plan

- [ ] `/money check` — verify ephemeral reply still works and balance is correct
- [ ] `/money pay` — verify payment processes correctly and balance updates
- [ ] `/money spend` — verify spend deducts correctly
- [ ] `/money take` — verify take adds correctly
- [ ] Confirm no regression when channel has no game data (`isdeleted` path)

Made with [Cursor](https://cursor.com)