### PR TITLE
fix(tracing): replace span.recordError with span.recordException

### DIFF
--- a/modules/GameFormatter.js
+++ b/modules/GameFormatter.js
@@ -277,7 +277,7 @@ class GameFormatter {
         await tableRenderer.generateTable();
         return new AttachmentBuilder(await tableRenderer.renderToBuffer(), { name: `status-table.png` });
       } catch (err) {
-        span.recordError(err);
+        span.recordException(err);
         span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
         throw err;
       } finally {
@@ -639,7 +639,7 @@ class GameFormatter {
 
         return canvas.toBuffer();
       } catch (err) {
-        span.recordError(err);
+        span.recordException(err);
         span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
         throw err;
       } finally {
@@ -1277,7 +1277,7 @@ class GameFormatter {
       try {
         return await this._generateConsolidatedPlayAreaImageInner(playersWithPlayAreas, guild);
       } catch (err) {
-        span.recordError(err);
+        span.recordException(err);
         span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
         throw err;
       } finally {


### PR DESCRIPTION
## Summary
- `span.recordError` is not part of the OpenTelemetry API and throws a `TypeError` at runtime
- Replaced all 3 occurrences in `GameFormatter.js` with the correct `span.recordException`

## Test plan
- [ ] Trigger a code path that hits a span error (e.g. force a canvas render failure) and confirm no `TypeError` is thrown
- [ ] Verify the exception is recorded in Honeycomb traces

Made with [Cursor](https://cursor.com)