### PR TITLE
feat(tracing): add OTel spans for BGG HTTP calls and filter heartbeat noise

### DIFF
--- a/modules/BoardGameGeek.js
+++ b/modules/BoardGameGeek.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder, AttachmentBuilder } = require("discord.js");
-const fetch = require("node-fetch");
 const { parse } = require("fast-xml-parser");
 const { find, cloneDeep, take } = require("lodash");
 const { createCanvas, Image, loadImage } = require("canvas");
@@ -8,6 +7,9 @@ const TurndownService = require("turndown");
 const Formatter = require('./GameFormatter')
 const GameDB = require('../db/anygame.js')
 const { XMLParser } = require("fast-xml-parser");
+const { trace, SpanStatusCode } = require("@opentelemetry/api");
+
+const tracer = trace.getTracer("discord-bot:bgg");
 
 class BoardGameGeek {
   constructor(gameId, discordClient, interaction) {
@@ -80,29 +82,45 @@ class BoardGameGeek {
   }
 
   async LoadBggData() {
-    let gameInfoResp = await fetch(
-      `https://api.geekdo.com/xmlapi/boardgame/${this.gameId}?stats=1`,
-      {
-        headers: {
-          'Authorization': `Bearer ${this.discordClient.config.BGGToken}`
-        }
+    return tracer.startActiveSpan("bgg.fetch_data", async (span) => {
+      span.setAttributes({
+        "bgg.game_id": String(this.gameId),
+        "bgg.url": `https://api.geekdo.com/xmlapi/boardgame/${this.gameId}?stats=1`,
+      });
+      try {
+        let gameInfoResp = await fetch(
+          `https://api.geekdo.com/xmlapi/boardgame/${this.gameId}?stats=1`,
+          {
+            headers: {
+              'Authorization': `Bearer ${this.discordClient.config.BGGToken}`
+            }
+          }
+        );
+        span.setAttribute("http.response.status_code", gameInfoResp.status);
+        const text = await gameInfoResp.text();
+        const parser = new XMLParser({
+          attributeNamePrefix: "",
+          textNodeName: "text",
+          ignoreAttributes: false,
+          ignoreNameSpace: true,
+          allowBooleanAttributes: true,
+        });
+        this.gameInfo = parser.parse(text).boardgames.boardgame;
+
+        const gameName = Array.isArray(this.gameInfo.name)
+          ? find(this.gameInfo.name, { primary: "true" }).text
+          : this.gameInfo.name.text;
+
+        this.gameName = he.decode(gameName);
+        span.setAttribute("bgg.game_name", this.gameName);
+      } catch (err) {
+        span.recordError(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+        throw err;
+      } finally {
+        span.end();
       }
-    );
-    const text = await gameInfoResp.text();
-    const parser = new XMLParser({
-      attributeNamePrefix: "",
-      textNodeName: "text",
-      ignoreAttributes: false,
-      ignoreNameSpace: true,
-      allowBooleanAttributes: true,
     });
-    this.gameInfo = parser.parse(text).boardgames.boardgame;
-
-    const gameName = Array.isArray(this.gameInfo.name)
-      ? find(this.gameInfo.name, { primary: "true" }).text
-      : this.gameInfo.name.text;
-
-    this.gameName = he.decode(gameName);
   }
 
   async LoadEmbeds(detailsType) {
@@ -146,7 +164,6 @@ class BoardGameGeek {
 
   async GetGameImageEmbed() {
     if (!this.gameInfo.image) {
-        // If no image is available, create a basic embed without an image
         const imageEmbed = new EmbedBuilder()
             .setTitle(this.gameName)
             .setURL(`https://boardgamegeek.com/boardgame/${this.gameId}`);
@@ -154,28 +171,44 @@ class BoardGameGeek {
         return;
     }
 
-    const gameImage = await loadImage(this.gameInfo.image);
-    const scaledWidth = 600;
-    const canvas = createCanvas(scaledWidth, (scaledWidth / gameImage.width) * gameImage.height);
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(gameImage, 0, 0, scaledWidth, (scaledWidth / gameImage.width) * gameImage.height);
-    
-    const imageAttach = new AttachmentBuilder(
-        canvas.toBuffer(),
-        {name: `gameImage.png`}
-    );
-    this.attachments.push(imageAttach);
+    return tracer.startActiveSpan("bgg.load_image", async (span) => {
+      span.setAttribute("bgg.image_url", this.gameInfo.image);
+      try {
+        const gameImage = await loadImage(this.gameInfo.image);
+        const scaledWidth = 600;
+        const canvas = createCanvas(scaledWidth, (scaledWidth / gameImage.width) * gameImage.height);
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(gameImage, 0, 0, scaledWidth, (scaledWidth / gameImage.width) * gameImage.height);
 
-    const imageEmbed = new EmbedBuilder()
-        .setTitle(this.gameName)
-        .setURL(`https://boardgamegeek.com/boardgame/${this.gameId}`)
-        .setImage(`attachment://gameImage.png`);
-    this.embeds.push(imageEmbed);
+        span.setAttributes({
+          "bgg.image.original_width": gameImage.width,
+          "bgg.image.original_height": gameImage.height,
+        });
 
-    // Explicitly free resources
-    canvas.width = 1;
-    canvas.height = 1;
-    ctx.clearRect(0, 0, 1, 1);
+        const imageAttach = new AttachmentBuilder(
+            canvas.toBuffer(),
+            {name: `gameImage.png`}
+        );
+        this.attachments.push(imageAttach);
+
+        const imageEmbed = new EmbedBuilder()
+            .setTitle(this.gameName)
+            .setURL(`https://boardgamegeek.com/boardgame/${this.gameId}`)
+            .setImage(`attachment://gameImage.png`);
+        this.embeds.push(imageEmbed);
+
+        // Explicitly free resources
+        canvas.width = 1;
+        canvas.height = 1;
+        ctx.clearRect(0, 0, 1, 1);
+      } catch (err) {
+        span.recordError(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
   }
 
   GetGameDetailsEmbed() {

--- a/tracing.js
+++ b/tracing.js
@@ -84,6 +84,13 @@ if (!apiKey) {
       const method = options.method ?? "UNKNOWN";
       const routeData = REST.generateRouteData(options.fullRoute, method);
       const route = routeData.bucketRoute ?? options.fullRoute ?? "unknown";
+
+      // The periodic client.application.fetch() call hits GET /applications/@me every 60 s.
+      // It has no parent span and adds heartbeat noise to every trace view — drop it.
+      if (method === "GET" && route === "/applications/@me") {
+        return originalQueueRequest.apply(this, arguments);
+      }
+
       return discordRestTracer.startActiveSpan(
         `discord.rest ${method} ${route}`,
         async (span) => {


### PR DESCRIPTION
## Summary

- **`modules/BoardGameGeek.js`**: Added manual OTel spans (`bgg.fetch_data` and `bgg.load_image`) around the two HTTP-heavy operations in the BGG module. Because Bun's native `fetch` is not patched by Node.js auto-instrumentations, these calls were previously invisible in traces. Each span captures relevant attributes (`bgg.game_id`, `bgg.url`, `http.response.status_code`, `bgg.game_name`, `bgg.image_url`, image dimensions) and records errors with proper span status. Also removes the leftover `node-fetch` import that was no longer used.
- **`tracing.js`**: Added an early-return filter inside the `queueRequest` patch to drop the `discord.rest GET /applications/@me` span. This span is emitted every 60 s by the `setInterval(() => client.application.fetch())` heartbeat, has no parent span, and was polluting every trace view with low-signal noise.

## Test plan

- [x] Run the bot locally and trigger a BGG lookup (`/bgg`); confirm `bgg.fetch_data` and `bgg.load_image` spans appear in Honeycomb nested under the command span.
- [x] Confirm `http.response.status_code` and `bgg.game_name` attributes are populated on the `bgg.fetch_data` span.
- [x] Wait ~60 s and confirm no `discord.rest GET /applications/@me` spans appear in Honeycomb.
- [ ] Confirm all other Discord REST spans (e.g. `POST /channels/{id}/messages`) still appear normally.
- [ ] Force a BGG fetch error (e.g. bad game ID) and confirm the span records the error and sets `ERROR` status.

Made with [Cursor](https://cursor.com)