### PR TITLE
Optimize Phase 1 card commands: concurrent deferReply+getGameData and secondary-render

### DIFF
--- a/subcommands/cards/check.js
+++ b/subcommands/cards/check.js
@@ -11,9 +11,10 @@ class Check {
             let gameData = await GameHelper.getGameData(client, interaction)
             await GameHelper.getDeckAutocomplete(gameData, interaction)
         } else {
-            await interaction.deferReply()
-
-            let gameData = await GameHelper.getGameData(client, interaction)
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ]);
             if (gameData.isdeleted) {
                 await interaction.editReply({ content: `There is no game in this channel.`})
                 return
@@ -26,11 +27,12 @@ class Check {
                 return
             } 
 
-            let followup = await Formatter.multiCard(deck.piles.discard.cards, `All Discards in ${deck.name}`)
-
-            await interaction.editReply({ 
-                content: `${interaction.member.displayName} is looking at the ${deck.name} discard pile`
-            })
+            const [, followup] = await Promise.all([
+                interaction.editReply({ 
+                    content: `${interaction.member.displayName} is looking at the ${deck.name} discard pile`
+                }),
+                Formatter.multiCard(deck.piles.discard.cards, `All Discards in ${deck.name}`)
+            ]);
 
             await interaction.followUp({ embeds: [...followup[0]], files: [...followup[1]], flags: MessageFlags.Ephemeral })
         }

--- a/subcommands/cards/deckpeek.js
+++ b/subcommands/cards/deckpeek.js
@@ -10,9 +10,10 @@ module.exports = {
             await GameHelper.getDeckAutocomplete(gameData, interaction)
         } else {
             try {
-                await interaction.deferReply()
-
-                let gameData = await GameHelper.getGameData(client, interaction);
+                const [, gameData] = await Promise.all([
+                    interaction.deferReply(),
+                    GameHelper.getGameData(client, interaction)
+                ]);
                 const deckName = interaction.options.getString('deck');
                 let depth = interaction.options.getInteger('depth') ?? 1;
                 // Fetch the deck from the DB

--- a/subcommands/cards/discard.js
+++ b/subcommands/cards/discard.js
@@ -26,9 +26,10 @@ class Discard {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         let player = find(gameData.players, {userId: interaction.user.id})
 
         if (gameData.isdeleted) {
@@ -93,13 +94,13 @@ class Discard {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
-        await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-            content: `${interaction.member.displayName} has Discarded a card${destination !== 'discard' ? ' to ' + destinationName : ''}`
-        });
-
-        await interaction.editReply({ content: `You discarded ${Formatter.cardShortName(card)}${destination !== 'discard' ? ' to ' + destinationName : ''}.` });
-
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player);
+        const [, , handInfo] = await Promise.all([
+            GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+                content: `${interaction.member.displayName} has Discarded a card${destination !== 'discard' ? ' to ' + destinationName : ''}`
+            }),
+            interaction.editReply({ content: `You discarded ${Formatter.cardShortName(card)}${destination !== 'discard' ? ' to ' + destinationName : ''}.` }),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral };
         if (handInfo.attachments.length > 0) {
             privateFollowup.files = [...handInfo.attachments];

--- a/subcommands/cards/draftreturn.js
+++ b/subcommands/cards/draftreturn.js
@@ -22,9 +22,10 @@ class Take {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -70,9 +71,11 @@ class Take {
         
         //client.setGameData(`game-${interaction.channel.id}`, gameData)
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
-        await interaction.editReply({ content: `${interaction.member.displayName} has un-drafted a card!`})
-                        
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+
+        const [, handInfo] = await Promise.all([
+            interaction.editReply({ content: `${interaction.member.displayName} has un-drafted a card!`}),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 content: `You un-drafted:`, 

--- a/subcommands/cards/drafttake.js
+++ b/subcommands/cards/drafttake.js
@@ -26,9 +26,10 @@ class Take {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -60,7 +61,12 @@ class Take {
             console.warn('Failed to record draft take in history:', error)
         }
         
-        await interaction.editReply({ content: `${interaction.member.displayName} has drafted a card!`})
+        // The reply and the hand render are independent (the render only needs the
+        // already-mutated in-memory gameData/player), so run them concurrently.
+        const [, handInfo] = await Promise.all([
+            interaction.editReply({ content: `${interaction.member.displayName} has drafted a card!`}),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
 
         let cardsLeft = player.hands.draft.length
         let shouldPass = true
@@ -79,7 +85,6 @@ class Take {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
         if (handInfo.attachments.length > 0){
             await interaction.followUp({ 
                 content: `You drafted:`, 

--- a/subcommands/cards/draw.js
+++ b/subcommands/cards/draw.js
@@ -13,8 +13,10 @@ class Draw {
             return
         }
 
-        await interaction.deferReply()
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
         
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -73,11 +75,12 @@ class Draw {
         
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
                         
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData,
-          { content: `${interaction.member.displayName} drew a card from ${deck.name}` }
-        );
-
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData,
+              { content: `${interaction.member.displayName} drew a card from ${deck.name}` }
+            ),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 content: `You drew:`, 

--- a/subcommands/cards/drawmulti.js
+++ b/subcommands/cards/drawmulti.js
@@ -14,9 +14,10 @@ class DrawMulti {
             return
         }
 
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
             return
@@ -93,11 +94,12 @@ class DrawMulti {
         
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData,
-          { content: `${interaction.member.displayName} drew ${dealCount} cards from ${deck.name}${wasShuffled}` }
-        );
-            
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData,
+              { content: `${interaction.member.displayName} drew ${dealCount} cards from ${deck.name}${wasShuffled}` }
+            ),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 content: `Your Hand Now:`, 

--- a/subcommands/cards/flip.js
+++ b/subcommands/cards/flip.js
@@ -16,9 +16,10 @@ class Flip {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/flipmulti.js
+++ b/subcommands/cards/flipmulti.js
@@ -16,9 +16,10 @@ class FlipMulti {
             return
         }
 
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })

--- a/subcommands/cards/gameboardmove.js
+++ b/subcommands/cards/gameboardmove.js
@@ -35,9 +35,10 @@ class GameBoardMove {
             return
         }
 
-        await interaction.deferReply({ ephemeral: false })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ ephemeral: false }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
@@ -212,20 +213,27 @@ class GameBoardMove {
                 if (publicMessage.length > 2000) {
                     publicMessage = `${interaction.member.displayName} moved ${successfullyMovedCards.length} card(s) from Game Board to ${destinationName}. (Card list too long to display).`
                 }
-                
-                await selectionInteraction.update({
-                    content: publicMessage,
-                    components: []
-                })
 
-                // Show updated hand privately if destination was hand
+                // Show updated hand privately if destination was hand - the confirmation
+                // update and the hand render are independent, so run them concurrently.
                 if (destination === 'hand') {
-                    const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+                    const [, handInfo] = await Promise.all([
+                        selectionInteraction.update({
+                            content: publicMessage,
+                            components: []
+                        }),
+                        Formatter.playerSecretHandAndImages(gameData, player)
+                    ]);
                     const privateFollowup = { embeds: [...handInfo.embeds], ephemeral: true }
                     if (handInfo.attachments.length > 0) {
                         privateFollowup.files = [...handInfo.attachments]
                     }
                     await interaction.followUp(privateFollowup)
+                } else {
+                    await selectionInteraction.update({
+                        content: publicMessage,
+                        components: []
+                    })
                 }
             } else {
                 await selectionInteraction.update({

--- a/subcommands/cards/gameboardtake.js
+++ b/subcommands/cards/gameboardtake.js
@@ -29,9 +29,10 @@ class GameBoardTake {
             return
         }
 
-        await interaction.deferReply({})
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({}),
+            GameHelper.getGameData(client, interaction)
+        ]);
         
         const cardId = interaction.options.getString('card')
         const destination = interaction.options.getString('destination') || 'hand'
@@ -118,17 +119,20 @@ class GameBoardTake {
             publicMessage += ` to ${destinationName}`
         }
 
-        await interaction.editReply({ 
-            content: publicMessage})
-
-        // Show updated hand privately if destination was hand
+        // Show updated hand privately if destination was hand - the reply and the hand
+        // render are independent, so run them concurrently when a render is needed.
         if (destination === 'hand') {
-            const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+            const [, handInfo] = await Promise.all([
+                interaction.editReply({ content: publicMessage}),
+                Formatter.playerSecretHandAndImages(gameData, player)
+            ]);
             const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
             if (handInfo.attachments.length > 0) {
                 privateFollowup.files = [...handInfo.attachments]
             }
             await interaction.followUp(privateFollowup)
+        } else {
+            await interaction.editReply({ content: publicMessage})
         }
     }
 }

--- a/subcommands/cards/gameboardview.js
+++ b/subcommands/cards/gameboardview.js
@@ -4,9 +4,10 @@ const Formatter = require('../../modules/GameFormatter')
 
 class GameBoardView {
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -18,10 +19,11 @@ class GameBoardView {
             return
         }
 
-        let followup = await Formatter.multiCard(gameData.gameBoard, `All Cards on Game Board`)
-
-        await interaction.editReply({ 
-            content: `Game Board (${gameData.gameBoard.length} cards)`})
+        const [, followup] = await Promise.all([
+            interaction.editReply({ 
+                content: `Game Board (${gameData.gameBoard.length} cards)`}),
+            Formatter.multiCard(gameData.gameBoard, `All Cards on Game Board`)
+        ]);
 
         await interaction.followUp({ 
             embeds: [...followup[0]], 

--- a/subcommands/cards/pass.js
+++ b/subcommands/cards/pass.js
@@ -7,9 +7,10 @@ const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags} = require('disc
 
 class Pass {
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -90,11 +91,14 @@ class Pass {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-        await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-            content: `${interaction.member.displayName} passed ${passedCardsObjects.length} card(s) to ${selectedPlayer}.`
-        });
+        const [, senderHandInfo, receiverHandInfo] = await Promise.all([
+            GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+                content: `${interaction.member.displayName} passed ${passedCardsObjects.length} card(s) to ${selectedPlayer}.`
+            }),
+            Formatter.playerSecretHandAndImages(gameData, player),
+            Formatter.playerSecretHandAndImages(gameData, targetPlayer)
+        ]);
 
-        var senderHandInfo = await Formatter.playerSecretHandAndImages(gameData, player)
         await interaction.followUp({
             content: `You passed ${passedCardsObjects.length} card(s) to ${selectedPlayer.username}. Your hand is now:`,
             embeds: [...senderHandInfo.embeds],
@@ -102,7 +106,6 @@ class Pass {
             flags: MessageFlags.Ephemeral
         });
 
-        var receiverHandInfo = await Formatter.playerSecretHandAndImages(gameData, targetPlayer)
         await interaction.guild.members.fetch(selectedPlayer.id).then(member => {
             member.send({
                 content: `You received ${passedCardsObjects.length} card(s) from ${interaction.member.displayName}. Your hand is now:`,

--- a/subcommands/cards/pick.js
+++ b/subcommands/cards/pick.js
@@ -12,9 +12,10 @@ class Pick {
         return
     }
 
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-    
-    let gameData = await GameHelper.getGameData(client, interaction)
+    const [, gameData] = await Promise.all([
+      interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+      GameHelper.getGameData(client, interaction)
+    ]);
     const inputDeck = interaction.options.getString('deck')
     const deck = GameHelper.getSpecificDeck(gameData, inputDeck, interaction.user.id)
     let player = find(gameData.players, {userId: interaction.user.id})

--- a/subcommands/cards/piledrawmultiple.js
+++ b/subcommands/cards/piledrawmultiple.js
@@ -13,9 +13,10 @@ class PileDrawMultiple {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         const pileId = interaction.options.getString('pile')
         const count = interaction.options.getInteger('count')
         
@@ -77,10 +78,11 @@ class PileDrawMultiple {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-        let followup = await Formatter.multiCard(drawnCards, `Cards Drawn from ${pile.name}`)
-        
-        await interaction.editReply({ 
-            content: `You drew ${count} cards from ${pile.name}`})
+        const [followup] = await Promise.all([
+            Formatter.multiCard(drawnCards, `Cards Drawn from ${pile.name}`),
+            interaction.editReply({ 
+                content: `You drew ${count} cards from ${pile.name}`})
+        ]);
 
         await interaction.followUp({ 
             embeds: [...followup[0]], 

--- a/subcommands/cards/pileflip.js
+++ b/subcommands/cards/pileflip.js
@@ -15,9 +15,10 @@ class PileFlip {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/pileflipmultiple.js
+++ b/subcommands/cards/pileflipmultiple.js
@@ -15,9 +15,10 @@ class PileFlipMultiple {
             return
         }
 
-        await interaction.deferReply()
-
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })

--- a/subcommands/cards/pilepeek.js
+++ b/subcommands/cards/pilepeek.js
@@ -11,9 +11,10 @@ class PilePeek {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -33,10 +34,11 @@ class PilePeek {
             return
         }
 
-        let followup = await Formatter.multiCard(pile.cards, `All Cards in ${pile.name}`)
-
-        await interaction.editReply({ 
-            content: `Peeking at ${pile.name} (${pile.cards.length} cards)${pile.isSecret ? ' 🔒' : ''}`})
+        const [, followup] = await Promise.all([
+            interaction.editReply({ 
+                content: `Peeking at ${pile.name} (${pile.cards.length} cards)${pile.isSecret ? ' 🔒' : ''}`}),
+            Formatter.multiCard(pile.cards, `All Cards in ${pile.name}`)
+        ]);
 
         await interaction.followUp({ 
             embeds: [...followup[0]], 

--- a/subcommands/cards/pileplay.js
+++ b/subcommands/cards/pileplay.js
@@ -24,9 +24,10 @@ class PilePlay {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -92,13 +93,13 @@ class PilePlay {
 
         const embeds = pile.isSecret ? [] : [Formatter.oneCard(playedCard)]
 
-        await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-            content: publicMessage,
-            additionalEmbeds: embeds
-        })
-
-        // Private follow-up with hand
-        const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+                content: publicMessage,
+                additionalEmbeds: embeds
+            }),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
         if (handInfo.attachments.length > 0) {
             privateFollowup.files = [...handInfo.attachments]

--- a/subcommands/cards/piletake.js
+++ b/subcommands/cards/piletake.js
@@ -13,9 +13,10 @@ class PileTake {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         const pileId = interaction.options.getString('pile')
         
         const player = find(gameData.players, {userId: interaction.user.id})

--- a/subcommands/cards/pileview.js
+++ b/subcommands/cards/pileview.js
@@ -10,9 +10,10 @@ class PileView {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -38,11 +39,12 @@ class PileView {
             return
         }
 
-        let followup = await Formatter.multiCard(pile.cards, `All Cards in ${pile.name}`)
-
-        await interaction.editReply({ 
-            content: `${interaction.member.displayName} is viewing ${pile.name} (${pile.cards.length} cards)`
-        })
+        const [, followup] = await Promise.all([
+            interaction.editReply({ 
+                content: `${interaction.member.displayName} is viewing ${pile.name} (${pile.cards.length} cards)`
+            }),
+            Formatter.multiCard(pile.cards, `All Cards in ${pile.name}`)
+        ]);
 
         await interaction.followUp({ 
             embeds: [...followup[0]], 

--- a/subcommands/cards/play.js
+++ b/subcommands/cards/play.js
@@ -28,9 +28,10 @@ class Play {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -162,10 +163,10 @@ class Play {
         if (replyFiles.length > 0) {
             replyOptions.files = replyFiles;
         }
-        await interaction.editReply(replyOptions);
-
-        // The ephemeral follow-up for hand status remains the same
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            interaction.editReply(replyOptions),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 embeds: [...handInfo.embeds],

--- a/subcommands/cards/playareadiscard.js
+++ b/subcommands/cards/playareadiscard.js
@@ -11,9 +11,10 @@ module.exports = {
     // For now, assuming it's routed directly and doesn't need its own data builder here.
 
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral }); // Start with ephemeral, can make non-ephemeral later if needed
-
-        const gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }), // Start with ephemeral, can make non-ephemeral later if needed
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             return interaction.editReply({ content: "No active game found in this channel."});
         }
@@ -129,35 +130,40 @@ module.exports = {
             // Ephemeral confirmation of action
             const successfullyDiscardedCards = discardedCards.filter(dc => !player.playArea.find(pc => pc.id === dc.id));
 
-            if (successfullyDiscardedCards.length > 0) {
-                await selectionInteraction.update({
-                    content: `You discarded ${successfullyDiscardedCards.length} card(s) from your play area: ${successfullyDiscardedCards.map(c => Formatter.cardShortName(c)).join(', ')}.`,
-                    components: []
-                });
-
-                // Public follow-up message
-                await interaction.followUp({
-                    content: `${interaction.member.displayName} discarded ${successfullyDiscardedCards.length} card(s) from their play area.`});
-            } else {
-                 await selectionInteraction.update({
-                    content: `No cards were ultimately discarded due to errors finding their discard piles.`,
-                    components: []
-                });
-            }
-
-
             // Display updated play area to the player (ephemeral)
             // This can be part of the selectionInteraction.update or a new followUp
             const playAreaEmbed = new EmbedBuilder()
                 .setColor(player.color || 13502711)
                 .setTitle("Your Updated Play Area");
 
-            const playAreaAttachment = await Formatter.genericCardZoneDisplay(
-                player.playArea, // Send the updated playArea
-                playAreaEmbed,
-                "Current Cards",
-                `PlayAreaUpdate-${player.userId}`
-            );
+            let mainConfirmPromise;
+            if (successfullyDiscardedCards.length > 0) {
+                mainConfirmPromise = selectionInteraction.update({
+                    content: `You discarded ${successfullyDiscardedCards.length} card(s) from your play area: ${successfullyDiscardedCards.map(c => Formatter.cardShortName(c)).join(', ')}.`,
+                    components: []
+                });
+            } else {
+                mainConfirmPromise = selectionInteraction.update({
+                    content: `No cards were ultimately discarded due to errors finding their discard piles.`,
+                    components: []
+                });
+            }
+
+            const [, playAreaAttachment] = await Promise.all([
+                mainConfirmPromise,
+                Formatter.genericCardZoneDisplay(
+                    player.playArea, // Send the updated playArea
+                    playAreaEmbed,
+                    "Current Cards",
+                    `PlayAreaUpdate-${player.userId}`
+                )
+            ]);
+
+            if (successfullyDiscardedCards.length > 0) {
+                // Public follow-up message
+                await interaction.followUp({
+                    content: `${interaction.member.displayName} discarded ${successfullyDiscardedCards.length} card(s) from their play area.`});
+            }
 
             const finalEphemeralReply = {
                 embeds: [playAreaEmbed],

--- a/subcommands/cards/playareagive.js
+++ b/subcommands/cards/playareagive.js
@@ -9,9 +9,10 @@ module.exports = {
     // Needs: .addUserOption(option => option.setName('target').setDescription('The player to give cards to').setRequired(true))
 
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-        const gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             return interaction.editReply({ content: "No active game found in this channel."});
         }
@@ -117,10 +118,6 @@ module.exports = {
             await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
             const givenCardsList = givenCards.map(c => Formatter.cardShortName(c)).join(', ');
-            await selectionInteraction.update({
-                content: `You gave ${givenCards.length} card(s) to ${targetUser.username}: ${givenCardsList}.`,
-                components: []
-            });
 
             let publicFollowUpContent = `${interaction.member.displayName} gave ${givenCards.length} card(s) to ${targetUser.username}'s play area`;
             if (givenCards.length > 0) {
@@ -129,15 +126,21 @@ module.exports = {
             if (publicFollowUpContent.length > 2000) { // Discord message limit
                 publicFollowUpContent = `${interaction.member.displayName} gave ${givenCards.length} card(s) to ${targetUser.username}'s play area. (Card list too long to display).`;
             }
-            await interaction.followUp({
-                content: publicFollowUpContent});
 
             // Display updated play areas
             const initiatorPlayAreaEmbed = new EmbedBuilder().setTitle("Your Updated Play Area").setColor(initiator.color || 13502711);
-            const initiatorAttachment = await Formatter.genericCardZoneDisplay(initiator.playArea, initiatorPlayAreaEmbed, "Your Cards", `PlayAreaUpdate-${initiator.userId}`);
-
             const targetPlayAreaEmbed = new EmbedBuilder().setTitle(`${targetUser.username}'s Updated Play Area`).setColor(targetPlayer.color || 13502711);
-            const targetAttachment = await Formatter.genericCardZoneDisplay(targetPlayer.playArea, targetPlayAreaEmbed, "Their Cards", `PlayAreaUpdate-${targetPlayer.userId}`);
+
+            const [, , initiatorAttachment, targetAttachment] = await Promise.all([
+                selectionInteraction.update({
+                    content: `You gave ${givenCards.length} card(s) to ${targetUser.username}: ${givenCardsList}.`,
+                    components: []
+                }),
+                interaction.followUp({
+                    content: publicFollowUpContent}),
+                Formatter.genericCardZoneDisplay(initiator.playArea, initiatorPlayAreaEmbed, "Your Cards", `PlayAreaUpdate-${initiator.userId}`),
+                Formatter.genericCardZoneDisplay(targetPlayer.playArea, targetPlayAreaEmbed, "Their Cards", `PlayAreaUpdate-${targetPlayer.userId}`)
+            ]);
 
             const statusFiles = [];
             if (initiatorAttachment) statusFiles.push(initiatorAttachment);

--- a/subcommands/cards/playareamove.js
+++ b/subcommands/cards/playareamove.js
@@ -36,9 +36,10 @@ module.exports = {
             return;
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-        const gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             return interaction.editReply({ content: "No active game found in this channel."});
         }
@@ -238,32 +239,40 @@ module.exports = {
                 const sourcePlayAreaEmbed = new EmbedBuilder()
                     .setTitle(`${sourceUser.username}'s Updated Play Area`)
                     .setColor(sourcePlayer.color || 13502711);
-                const sourceAttachment = await Formatter.genericCardZoneDisplay(
-                    sourcePlayer.playArea,
-                    sourcePlayAreaEmbed,
-                    "Their Cards",
-                    `PlayAreaUpdate-${sourcePlayer.userId}`
-                );
+
+                let destinationPlayer, destDisplayName, destPlayAreaEmbed;
+                if (destination === 'playarea') {
+                    destinationPlayer = find(gameData.players, { userId: destinationPlayerId });
+                    const destMember = interaction.guild.members.cache.get(destinationPlayerId);
+                    destDisplayName = destMember?.displayName || destinationPlayer.name || `Player ${destinationPlayer.order}`;
+                    destPlayAreaEmbed = new EmbedBuilder()
+                        .setTitle(`${destDisplayName}'s Updated Play Area`)
+                        .setColor(destinationPlayer.color || 13502711);
+                }
+
+                // Source and destination renders are independent of each other, so run them concurrently.
+                const [sourceAttachment, destAttachment] = await Promise.all([
+                    Formatter.genericCardZoneDisplay(
+                        sourcePlayer.playArea,
+                        sourcePlayAreaEmbed,
+                        "Their Cards",
+                        `PlayAreaUpdate-${sourcePlayer.userId}`
+                    ),
+                    destination === 'playarea'
+                        ? Formatter.genericCardZoneDisplay(
+                            destinationPlayer.playArea,
+                            destPlayAreaEmbed,
+                            "Their Cards",
+                            `PlayAreaUpdate-${destinationPlayer.userId}`
+                        )
+                        : Promise.resolve(null)
+                ]);
 
                 const statusFiles = [];
                 if (sourceAttachment) statusFiles.push(sourceAttachment);
                 const embeds = [sourcePlayAreaEmbed].filter(e => e.data.fields && e.data.fields.length > 0 || e.data.image);
 
                 if (destination === 'playarea') {
-                    const destinationPlayer = find(gameData.players, { userId: destinationPlayerId });
-                    const destMember = interaction.guild.members.cache.get(destinationPlayerId);
-                    const destDisplayName = destMember?.displayName || destinationPlayer.name || `Player ${destinationPlayer.order}`;
-                    
-                    const destPlayAreaEmbed = new EmbedBuilder()
-                        .setTitle(`${destDisplayName}'s Updated Play Area`)
-                        .setColor(destinationPlayer.color || 13502711);
-                    const destAttachment = await Formatter.genericCardZoneDisplay(
-                        destinationPlayer.playArea,
-                        destPlayAreaEmbed,
-                        "Their Cards",
-                        `PlayAreaUpdate-${destinationPlayer.userId}`
-                    );
-
                     if (destAttachment) statusFiles.push(destAttachment);
                     embeds.push(destPlayAreaEmbed);
                 }

--- a/subcommands/cards/playareapick.js
+++ b/subcommands/cards/playareapick.js
@@ -7,9 +7,10 @@ const { EmbedBuilder, StringSelectMenuBuilder, ActionRowBuilder, MessageFlags} =
 module.exports = {
     // data for subcommand group is in main cards.js
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-        const gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             return interaction.editReply({ content: "No active game found in this channel."});
         }
@@ -113,18 +114,19 @@ module.exports = {
 
             await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
-            // Ephemeral confirmation of action
-            await selectionInteraction.update({
-                content: `You picked up ${pickedCards.length} card(s) from your play area: ${pickedCards.map(c => Formatter.cardShortName(c)).join(', ')}. They have been added to your hand.`,
-                components: []
-            });
-
-            // Public follow-up message
-            await interaction.followUp({
-                content: `${interaction.member.displayName} picked up ${pickedCards.length} card(s) from their play area.`});
+            // Ephemeral confirmation of action, public follow-up, and the hand/play-area render
+            // are all independent of each other, so they can run concurrently.
+            const [, , handShowReply] = await Promise.all([
+                selectionInteraction.update({
+                    content: `You picked up ${pickedCards.length} card(s) from your play area: ${pickedCards.map(c => Formatter.cardShortName(c)).join(', ')}. They have been added to your hand.`,
+                    components: []
+                }),
+                interaction.followUp({
+                    content: `${interaction.member.displayName} picked up ${pickedCards.length} card(s) from their play area.`}),
+                Formatter.playerSecretHandAndImages(gameData, player)
+            ]);
 
             // Display updated hand and play area to the player (ephemeral)
-            const handShowReply = await Formatter.playerSecretHandAndImages(gameData, player);
             await interaction.followUp({
                 content: "Your updated hand and play area:",
                 embeds: handShowReply.embeds,

--- a/subcommands/cards/playareatake.js
+++ b/subcommands/cards/playareatake.js
@@ -9,9 +9,10 @@ module.exports = {
     // It needs a user option: .addUserOption(option => option.setName('target').setDescription('The player to take cards from').setRequired(true))
 
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-        const gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         if (gameData.isdeleted) {
             return interaction.editReply({ content: "No active game found in this channel."});
         }
@@ -119,10 +120,6 @@ module.exports = {
             await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
             const takenCardsList = takenCards.map(c => Formatter.cardShortName(c)).join(', ');
-            await selectionInteraction.update({
-                content: `You took ${takenCards.length} card(s) from ${targetUser.username}'s play area: ${takenCardsList}.`,
-                components: []
-            });
 
             let publicFollowUpContent = `${interaction.member.displayName} took ${takenCards.length} card(s) from ${targetUser.username}'s play area`;
             if (takenCards.length > 0) {
@@ -131,15 +128,21 @@ module.exports = {
             if (publicFollowUpContent.length > 2000) { // Discord message limit
                 publicFollowUpContent = `${interaction.member.displayName} took ${takenCards.length} card(s) from ${targetUser.username}'s play area. (Card list too long to display).`;
             }
-            await interaction.followUp({
-                content: publicFollowUpContent});
 
             // Display updated play areas (could be combined or sent separately)
             const initiatorPlayAreaEmbed = new EmbedBuilder().setTitle("Your Updated Play Area").setColor(initiator.color || 13502711);
-            const initiatorAttachment = await Formatter.genericCardZoneDisplay(initiator.playArea, initiatorPlayAreaEmbed, "Your Cards", `PlayAreaUpdate-${initiator.userId}`);
-
             const targetPlayAreaEmbed = new EmbedBuilder().setTitle(`${targetUser.username}'s Updated Play Area`).setColor(targetPlayer.color || 13502711);
-            const targetAttachment = await Formatter.genericCardZoneDisplay(targetPlayer.playArea, targetPlayAreaEmbed, "Their Cards", `PlayAreaUpdate-${targetPlayer.userId}`);
+
+            const [, , initiatorAttachment, targetAttachment] = await Promise.all([
+                selectionInteraction.update({
+                    content: `You took ${takenCards.length} card(s) from ${targetUser.username}'s play area: ${takenCardsList}.`,
+                    components: []
+                }),
+                interaction.followUp({
+                    content: publicFollowUpContent}),
+                Formatter.genericCardZoneDisplay(initiator.playArea, initiatorPlayAreaEmbed, "Your Cards", `PlayAreaUpdate-${initiator.userId}`),
+                Formatter.genericCardZoneDisplay(targetPlayer.playArea, targetPlayAreaEmbed, "Their Cards", `PlayAreaUpdate-${targetPlayer.userId}`)
+            ]);
 
             const statusFiles = [];
             if (initiatorAttachment) statusFiles.push(initiatorAttachment);

--- a/subcommands/cards/playmulti.js
+++ b/subcommands/cards/playmulti.js
@@ -6,9 +6,10 @@ const GameDB = require('../../db/anygame')
 
 class PlayMulti {
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -153,9 +154,10 @@ class PlayMulti {
         const followupOptions = { content: mainContent, components: [] };
         if (replyEmbeds.length > 0) followupOptions.embeds = replyEmbeds;
         if (replyFiles.length > 0) followupOptions.files = replyFiles;
-        await interaction.followUp(followupOptions);
-        
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            interaction.followUp(followupOptions),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 embeds: [...handInfo.embeds],

--- a/subcommands/cards/playsimultaneous.js
+++ b/subcommands/cards/playsimultaneous.js
@@ -10,9 +10,10 @@ const {
 
 class PlaySimultaneous {
   async execute(interaction, client) {
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-
-    let gameData = await GameHelper.getGameData(client, interaction);
+    const [, gameData] = await Promise.all([
+      interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+      GameHelper.getGameData(client, interaction)
+    ]);
 
     if (gameData.isdeleted) {
       return interaction.editReply({
@@ -131,18 +132,18 @@ class PlaySimultaneous {
       p.hands.simultaneous && p.hands.simultaneous.length > 0
     );
 
-    // Send a public followup message to notify other players
-    await interaction.followUp({
-      content: allPlayersSelected 
-        ? `${interaction.user} has selected their cards for simultaneous play! All players have now made their selections - time to reveal!`
-        : `${interaction.user} has selected their cards for simultaneous play!`});
-
-    await interaction.editReply({
-      content: `You have selected your cards for simultaneous play. Waiting for the reveal.`,
-      components: []});
-
-    // Show the player their current hand
-    var handInfo = await Formatter.playerSecretHandAndImages(gameData, player);
+    // Send a public followup message to notify other players, acknowledge the selection,
+    // and render the player's current hand all concurrently - they're independent of each other.
+    const [, , handInfo] = await Promise.all([
+      interaction.followUp({
+        content: allPlayersSelected 
+          ? `${interaction.user} has selected their cards for simultaneous play! All players have now made their selections - time to reveal!`
+          : `${interaction.user} has selected their cards for simultaneous play!`}),
+      interaction.editReply({
+        content: `You have selected your cards for simultaneous play. Waiting for the reveal.`,
+        components: []}),
+      Formatter.playerSecretHandAndImages(gameData, player)
+    ]);
     if (handInfo.attachments.length > 0) {
       await interaction.followUp({ 
         embeds: [...handInfo.embeds],

--- a/subcommands/cards/return.js
+++ b/subcommands/cards/return.js
@@ -26,9 +26,10 @@ class Rturn {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
         let player = find(gameData.players, {userId: interaction.user.id})
 
         if (gameData.isdeleted) {
@@ -89,13 +90,13 @@ class Rturn {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
-        await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-            content: `${interaction.member.displayName} returned a card${destination !== 'deck' ? ' to ' + destinationName : ''}`
-        });
-
-        await interaction.editReply({ content: `You returned ${Formatter.cardShortName(card)} to ${destinationName}.` });
-
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player);
+        const [, , handInfo] = await Promise.all([
+            GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+                content: `${interaction.member.displayName} returned a card${destination !== 'deck' ? ' to ' + destinationName : ''}`
+            }),
+            interaction.editReply({ content: `You returned ${Formatter.cardShortName(card)} to ${destinationName}.` }),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral };
         if (handInfo.attachments.length > 0) {
             privateFollowup.files = [...handInfo.attachments];

--- a/subcommands/cards/reveal.js
+++ b/subcommands/cards/reveal.js
@@ -23,9 +23,10 @@ class Reveal {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -66,12 +67,13 @@ class Reveal {
         // Save game data to persist history entry
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
-        await interaction.editReply({ content: "Revealing a card:",
-        embeds: [
-            Formatter.oneCard(card),
-        ]})
-
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            interaction.editReply({ content: "Revealing a card:",
+            embeds: [
+                Formatter.oneCard(card),
+            ]}),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length >0){
             await interaction.followUp({ 
                 embeds: [...handInfo.embeds],

--- a/subcommands/cards/review.js
+++ b/subcommands/cards/review.js
@@ -11,9 +11,10 @@ class Review {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -27,10 +28,11 @@ class Review {
             return
         } 
         
-        let followup = await Formatter.multiCard(deck.allCards, `All cards in ${deck.name}`)
-
-        await interaction.editReply({ 
-            content: `${interaction.member.displayName} is reviewing the total makeup of ${deck.name}`})
+        const [, followup] = await Promise.all([
+            interaction.editReply({ 
+                content: `${interaction.member.displayName} is reviewing the total makeup of ${deck.name}`}),
+            Formatter.multiCard(deck.allCards, `All cards in ${deck.name}`)
+        ]);
         
         await interaction.followUp({ embeds: [...followup[0]], files: [...followup[1]], flags: MessageFlags.Ephemeral })
     }

--- a/subcommands/cards/show.js
+++ b/subcommands/cards/show.js
@@ -5,9 +5,10 @@ const { MessageFlags } = require('discord.js')
 
 class Show {
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/simultaneousreveal.js
+++ b/subcommands/cards/simultaneousreveal.js
@@ -5,9 +5,10 @@ const Formatter = require("../../modules/GameFormatter");
 
 class SimultaneousReveal {
   async execute(interaction, client) {
-    await interaction.deferReply();
-
-    let gameData = await GameHelper.getGameData(client, interaction);
+    const [, gameData] = await Promise.all([
+      interaction.deferReply(),
+      GameHelper.getGameData(client, interaction)
+    ]);
 
     if (gameData.isdeleted) {
       return interaction.editReply({

--- a/subcommands/cards/steal.js
+++ b/subcommands/cards/steal.js
@@ -7,9 +7,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Steal {
     async execute(interaction, client) {
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -55,12 +56,13 @@ class Steal {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
         
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData, {
-            content: `${interaction.member.displayName} stole a card from ${interaction.guild.members.cache.get(targetPlayer.userId)?.displayName}`
-        })
-
         // Send private message to player about what they stole
-        var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        const [, handInfo] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData, {
+                content: `${interaction.member.displayName} stole a card from ${interaction.guild.members.cache.get(targetPlayer.userId)?.displayName}`
+            }),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ]);
         if (handInfo.attachments.length > 0) {
             await interaction.followUp({ 
                 content: `You Stole:`, 


### PR DESCRIPTION
## Summary

Phase 1 of a broader defer-reply / rendering performance rollout for `subcommands/cards/*.js`. Two independent async optimization patterns are applied, both purely about concurrency/sequencing — no business logic, embed content, or reply text was changed anywhere in this PR.

### Pattern A — concurrent `deferReply` + `getGameData`

Previously each command did:

```js
await interaction.deferReply()
let gameData = await GameHelper.getGameData(client, interaction)
```

These two calls are independent (the DB fetch doesn't need the deferReply to resolve first), so they're now run concurrently:

```js
const [, gameData] = await Promise.all([
    interaction.deferReply(),
    GameHelper.getGameData(client, interaction)
]);
```

This overlaps the Discord ack round-trip with the DB fetch instead of paying both latencies sequentially, on every card command invocation.

### Pattern B — concurrent main-reply + secondary render

Some commands (e.g. `/cards play`) do a second render step after the main reply — for example rendering an updated hand to send as a follow-up. Previously this render was kicked off only after the main `editReply` had fully completed:

```js
await interaction.editReply(replyOptions);
var handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
```

Since the secondary render has no dependency on the main reply completing, it's now run concurrently with it:

```js
const [, handInfo] = await Promise.all([
    interaction.editReply(replyOptions),
    Formatter.playerSecretHandAndImages(gameData, player)
]);
```

## Files changed (35 total)

**Both Pattern A and Pattern B (26 files)** — these commands have an independent secondary render alongside their main reply:

`check.js`, `discard.js`, `draftreturn.js`, `drafttake.js`, `draw.js`, `drawmulti.js`, `gameboardmove.js`, `gameboardtake.js`, `gameboardview.js`, `pass.js`, `piledrawmultiple.js`, `pilepeek.js`, `pileplay.js`, `pileview.js`, `play.js`, `playareadiscard.js`, `playareagive.js`, `playareamove.js`, `playareapick.js`, `playareatake.js`, `playmulti.js`, `playsimultaneous.js`, `return.js`, `reveal.js`, `review.js`, `steal.js`

**Pattern A only (9 files)** — these either feed their render directly into the single reply payload, or their structure doesn't fit the independent-secondary-render shape, so only the `deferReply`+`getGameData` optimization applies:

`deckpeek.js`, `flip.js`, `flipmulti.js`, `pick.js`, `pileflip.js`, `pileflipmultiple.js`, `piletake.js`, `show.js`, `simultaneousreveal.js`

## What did NOT change

No business logic, embed content, or reply text changed anywhere in this PR — only the sequencing/concurrency of independent async calls.

## Rollout

This is **Phase 1**, covering the `subcommands/cards/` command group. Additional phases covering other command groups will follow in future PRs.

## Test plan

- [ ] Smoke-test a representative command from each pattern group (e.g. `/cards play` for Pattern A+B, `/cards flip` for Pattern A only) to confirm replies/follow-ups still render correctly and in the right order.
- [ ] Confirm no regression in error handling paths (e.g. no-game / deleted-game early exits) since those still run after the `Promise.all` resolves.

Made with [Cursor](https://cursor.com)