### PR TITLE
Fix known bugs in cards commands

### DIFF
--- a/modules/GameFormatter.js
+++ b/modules/GameFormatter.js
@@ -607,9 +607,16 @@ class GameFormatter {
         const cardsInFirstRow = Math.min(imgList.length, 6);
         const canvasWidth = cardsInFirstRow * 200;
         const cardWidth = 200;
+        const fallbackCardHeight = 280;
 
-        // Fetch all images in parallel
-        const cardImages = await Promise.all(imgList.map(url => loadImage(url)));
+        // Load images individually so a single failed/unreachable URL degrades to a
+        // placeholder instead of aborting the whole render (and the command with it).
+        const cardImages = await Promise.all(imgList.map(url =>
+          loadImage(url).catch(err => {
+            console.error(`Failed to load card image: ${url}`, err);
+            return null;
+          })
+        ));
 
         // Layout pass: calculate row boundaries to determine final canvas height
         let rowstart = 0;
@@ -617,7 +624,7 @@ class GameFormatter {
         const layout = [];
         for (let i = 0; i < cardImages.length; i++) {
           const cardImage = cardImages[i];
-          const cardHeight = (cardWidth / cardImage.width) * cardImage.height;
+          const cardHeight = cardImage ? (cardWidth / cardImage.width) * cardImage.height : fallbackCardHeight;
           const spot = i % 6;
           if (spot === 0) {
             rowstart = rowend;
@@ -634,7 +641,17 @@ class GameFormatter {
         // Draw pass (sequential canvas ops using pre-loaded images)
         for (let i = 0; i < cardImages.length; i++) {
           const { rowstart, cardHeight } = layout[i];
-          ctx.drawImage(cardImages[i], (i % 6) * cardWidth, rowstart, cardWidth, cardHeight);
+          const x = (i % 6) * cardWidth;
+          if (cardImages[i]) {
+            ctx.drawImage(cardImages[i], x, rowstart, cardWidth, cardHeight);
+          } else {
+            ctx.fillStyle = "#cccccc";
+            ctx.fillRect(x, rowstart, cardWidth, cardHeight);
+            ctx.fillStyle = "#000000";
+            ctx.font = "16px Open Sans";
+            ctx.textAlign = "center";
+            ctx.fillText("No Image", x + cardWidth / 2, rowstart + cardHeight / 2);
+          }
         }
 
         return canvas.toBuffer();

--- a/modules/GameStatusHelper.js
+++ b/modules/GameStatusHelper.js
@@ -27,7 +27,7 @@ class GameStatusHelper {
     await this.cleanUpPreviousMessage(interaction.channel, gameData);
 
     // Now, always send a new, full status message.
-    const fullReply = await Formatter.createGameStatusReply(gameData, interaction.guild, client.user.id, options);
+    const fullReply = await this.buildStatusReplyOptions(gameData, interaction.guild, client.user.id, options);
 
     const replyOptions = {
         ...fullReply,
@@ -57,8 +57,20 @@ class GameStatusHelper {
     await this.cleanUpPreviousMessage(channel, gameData);
 
     // Now, always send a new, full status message.
-    const fullReply = await Formatter.createGameStatusReply(gameData, channel.guild, client.user.id, options);
-    const sentMessage = await channel.send({ ...fullReply, fetchReply: true });
+    const fullReply = await this.buildStatusReplyOptions(gameData, channel.guild, client.user.id, options);
+
+    // Callers can opt in via options.resolveDeferredReply when the original
+    // interaction (deferred publicly) hasn't been resolved by any other means -
+    // otherwise it would be left stuck on "thinking..." while this status update
+    // is posted as a separate channel message. Callers that already resolve the
+    // interaction themselves (e.g. an ephemeral defer + separate editReply/followUp)
+    // are unaffected, since this defaults to off and keeps sending a new channel message.
+    let sentMessage;
+    if (options.resolveDeferredReply && (interaction.deferred || interaction.replied)) {
+        sentMessage = await interaction.editReply({ ...fullReply, fetchReply: true });
+    } else {
+        sentMessage = await channel.send({ ...fullReply, fetchReply: true });
+    }
 
     // Persist the status update result to the database
     const statusUpdateResult = {
@@ -66,6 +78,23 @@ class GameStatusHelper {
         lastStatusMessageTimestamp: Date.now()
     };
     await this.persistStatusUpdate(client, interaction, gameData, statusUpdateResult);
+  }
+
+  // Single choke point for building the full game status reply (table image,
+  // embeds, etc). Rendering can fail (e.g. a bad card image URL, canvas error),
+  // so this degrades to a text-only reply rather than letting the failure
+  // propagate and leave the interaction with no response at all.
+  static async buildStatusReplyOptions(gameData, guild, clientUserId, options = {}) {
+    try {
+        return await Formatter.createGameStatusReply(gameData, guild, clientUserId, options);
+    } catch (error) {
+        console.error('Failed to render game status; falling back to a text-only status update.', error);
+        const fallback = { embeds: [], files: [] };
+        fallback.content = options.content
+            ? `${options.content}\n\n⚠️ Could not render the full game status due to an error.`
+            : '⚠️ Could not render the full game status due to an error.';
+        return fallback;
+    }
   }
 
   static async persistStatusUpdate(client, interaction, gameData, publicUpdateResult) {

--- a/subcommands/cards/burn.js
+++ b/subcommands/cards/burn.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const GameHelper = require('../../modules/GlobalGameHelper');
 const GameDB = require('../../db/anygame.js');
 // No Formatter needed as we are not displaying card details
@@ -61,7 +62,7 @@ class Burn {
         } else {
              targetPile = GameHelper.getGlobalPile(gameData, destination);
              if (!targetPile) {
-                 await interaction.editReply({ content: 'Pile not found!', ephemeral: true });
+                 await interaction.editReply({ content: 'Pile not found!', flags: MessageFlags.Ephemeral });
                  return;
              }
              destinationName = targetPile.name;

--- a/subcommands/cards/flipmulti.js
+++ b/subcommands/cards/flipmulti.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js')
 const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
 const Formatter = require('../../modules/GameFormatter')
@@ -22,7 +23,7 @@ class FlipMulti {
         ]);
 
         if (gameData.isdeleted) {
-            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
+            await interaction.editReply({ content: `There is no game in this channel.`, flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -33,14 +34,14 @@ class FlipMulti {
         const deck = GameHelper.getSpecificDeck(gameData, inputDeck, interaction.user.id)
 
         if (!deck || deck.piles.draw.cards.length < 1) {
-            await interaction.editReply({ content: "No cards in draw pile", ephemeral: true })
+            await interaction.editReply({ content: "No cards in draw pile", flags: MessageFlags.Ephemeral })
             return
         }
 
         if (deck.piles.draw.cards.length < count) {
             await interaction.editReply({
                 content: `Not enough cards in draw pile! (has ${deck.piles.draw.cards.length}, requested ${count})`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return
         }
@@ -61,7 +62,7 @@ class FlipMulti {
             const pile = GameHelper.getGlobalPile(gameData, destination)
             if (!pile) {
                 deck.piles.draw.cards.unshift(...flippedCards)
-                await interaction.editReply({ content: 'Pile not found!', ephemeral: true })
+                await interaction.editReply({ content: 'Pile not found!', flags: MessageFlags.Ephemeral })
                 return
             }
             pile.cards.push(...flippedCards)

--- a/subcommands/cards/gameboarddiscard.js
+++ b/subcommands/cards/gameboarddiscard.js
@@ -3,7 +3,7 @@ const GameDB = require('../../db/anygame.js')
 const { find, findIndex, sortBy, filter } = require('lodash')
 const Formatter = require('../../modules/GameFormatter')
 const GameStatusHelper = require('../../modules/GameStatusHelper')
-const { StringSelectMenuBuilder, ActionRowBuilder } = require('discord.js')
+const { StringSelectMenuBuilder, ActionRowBuilder, MessageFlags } = require('discord.js')
 
 class GameBoardDiscard {
     async execute(interaction, client) {
@@ -75,7 +75,7 @@ class GameBoardDiscard {
             if (!pile) {
                 // Return card to board if pile not found
                 gameData.gameBoard.splice(cardIndex, 0, discardedCard)
-                await interaction.editReply({ content: 'Pile not found!', ephemeral: true })
+                await interaction.editReply({ content: 'Pile not found!', flags: MessageFlags.Ephemeral })
                 return
             }
             pile.cards.push(discardedCard)

--- a/subcommands/cards/gameboardmove.js
+++ b/subcommands/cards/gameboardmove.js
@@ -2,7 +2,7 @@ const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
 const { find, findIndex, sortBy, filter } = require('lodash')
 const Formatter = require('../../modules/GameFormatter')
-const { EmbedBuilder, StringSelectMenuBuilder, ActionRowBuilder } = require('discord.js')
+const { EmbedBuilder, StringSelectMenuBuilder, ActionRowBuilder, MessageFlags } = require('discord.js')
 
 class GameBoardMove {
     async execute(interaction, client) {
@@ -41,24 +41,24 @@ class GameBoardMove {
         ]);
 
         if (gameData.isdeleted) {
-            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
+            await interaction.editReply({ content: `There is no game in this channel.`, flags: MessageFlags.Ephemeral })
             return
         }
 
         const player = find(gameData.players, {userId: interaction.user.id})
         if (!player) {
-            await interaction.editReply({ content: "You must be a player in this game!", ephemeral: true })
+            await interaction.editReply({ content: "You must be a player in this game!", flags: MessageFlags.Ephemeral })
             return
         }
 
         if (!gameData.gameBoard || gameData.gameBoard.length < 1) {
-            await interaction.editReply({ content: `No cards on the Game Board!`, ephemeral: true })
+            await interaction.editReply({ content: `No cards on the Game Board!`, flags: MessageFlags.Ephemeral })
             return
         }
 
         const destination = interaction.options.getString('destination')
         if (!destination) {
-            await interaction.editReply({ content: "You must specify a destination.", ephemeral: true })
+            await interaction.editReply({ content: "You must specify a destination.", flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -66,14 +66,14 @@ class GameBoardMove {
 
         // Validate destination-specific requirements
         if (destination === 'playarea' && !destinationPlayerId) {
-            await interaction.editReply({ content: "You must specify a destination player when destination is 'Play Area'.", ephemeral: true })
+            await interaction.editReply({ content: "You must specify a destination player when destination is 'Play Area'.", flags: MessageFlags.Ephemeral })
             return
         }
 
         if (destination === 'playarea') {
             const destinationPlayer = find(gameData.players, { userId: destinationPlayerId })
             if (!destinationPlayer) {
-                await interaction.editReply({ content: "Destination player not found in the game.", ephemeral: true })
+                await interaction.editReply({ content: "Destination player not found in the game.", flags: MessageFlags.Ephemeral })
                 return
             }
         }
@@ -86,7 +86,7 @@ class GameBoardMove {
         }))
 
         if (options.length > 25) {
-            await interaction.editReply({ content: `Game Board has too many cards to display in a single list. Only the first 25 are shown.`, ephemeral: true })
+            await interaction.editReply({ content: `Game Board has too many cards to display in a single list. Only the first 25 are shown.`, flags: MessageFlags.Ephemeral })
         }
 
         const selectMenu = new StringSelectMenuBuilder()
@@ -123,7 +123,7 @@ class GameBoardMove {
             gameData.gameBoard = newGameBoard
 
             if (movedCards.length === 0) {
-                await selectionInteraction.update({ content: "No valid cards were selected or an error occurred.", components: [], ephemeral: true })
+                await selectionInteraction.update({ content: "No valid cards were selected or an error occurred.", components: [], flags: MessageFlags.Ephemeral })
                 return
             }
 
@@ -135,7 +135,7 @@ class GameBoardMove {
                 const destinationPlayer = find(gameData.players, { userId: destinationPlayerId })
                 if (!destinationPlayer) {
                     gameData.gameBoard.push(...movedCards)
-                    await selectionInteraction.update({ content: 'Destination player not found! Cards returned to Game Board.', components: [], ephemeral: true })
+                    await selectionInteraction.update({ content: 'Destination player not found! Cards returned to Game Board.', components: [], flags: MessageFlags.Ephemeral })
                     return
                 }
                 if (!destinationPlayer.playArea) {
@@ -168,7 +168,7 @@ class GameBoardMove {
                 if (!pile) {
                     // Return cards to gameboard if pile not found
                     gameData.gameBoard.push(...movedCards)
-                    await selectionInteraction.update({ content: 'Pile not found! Cards returned to Game Board.', components: [], ephemeral: true })
+                    await selectionInteraction.update({ content: 'Pile not found! Cards returned to Game Board.', components: [], flags: MessageFlags.Ephemeral })
                     return
                 }
                 pile.cards.push(...movedCards)
@@ -224,7 +224,7 @@ class GameBoardMove {
                         }),
                         Formatter.playerSecretHandAndImages(gameData, player)
                     ]);
-                    const privateFollowup = { embeds: [...handInfo.embeds], ephemeral: true }
+                    const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
                     if (handInfo.attachments.length > 0) {
                         privateFollowup.files = [...handInfo.attachments]
                     }
@@ -244,10 +244,10 @@ class GameBoardMove {
 
         } catch (e) {
             if (e.code === 'InteractionCollectorError') {
-                await interaction.editReply({ content: 'Card selection timed out.', components: [], ephemeral: true })
+                await interaction.editReply({ content: 'Card selection timed out.', components: [], flags: MessageFlags.Ephemeral })
             } else {
                 client.logger.log(e, 'error')
-                await interaction.editReply({ content: 'An error occurred during card selection for moving.', components: [], ephemeral: true })
+                await interaction.editReply({ content: 'An error occurred during card selection for moving.', components: [], flags: MessageFlags.Ephemeral })
             }
         }
     }

--- a/subcommands/cards/pilecreate.js
+++ b/subcommands/cards/pilecreate.js
@@ -52,7 +52,8 @@ class PileCreate {
 
         const secretText = isSecret ? ' (cards will be hidden)' : ''
         await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-            content: `${interaction.member.displayName} created a new pile: **${pileName}**${secretText}`
+            content: `${interaction.member.displayName} created a new pile: **${pileName}**${secretText}`,
+            resolveDeferredReply: true
         })
     }
 }

--- a/subcommands/cards/pileflip.js
+++ b/subcommands/cards/pileflip.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js')
 const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
 const Formatter = require('../../modules/GameFormatter')
@@ -62,7 +63,7 @@ class PileFlip {
 
             if (!deck) {
                 pile.cards.unshift(flippedCard)
-                await interaction.editReply({ content: 'No deck found to discard to. Use Game Board or a Custom Pile as destination.', ephemeral: true })
+                await interaction.editReply({ content: 'No deck found to discard to. Use Game Board or a Custom Pile as destination.', flags: MessageFlags.Ephemeral })
                 return
             }
             deck.piles.discard.cards.push(flippedCard)
@@ -72,7 +73,7 @@ class PileFlip {
             const destPile = GameHelper.getGlobalPile(gameData, destination)
             if (!destPile) {
                 pile.cards.unshift(flippedCard)
-                await interaction.editReply({ content: 'Destination pile not found!', ephemeral: true })
+                await interaction.editReply({ content: 'Destination pile not found!', flags: MessageFlags.Ephemeral })
                 return
             }
             destPile.cards.push(flippedCard)

--- a/subcommands/cards/pileflipmultiple.js
+++ b/subcommands/cards/pileflipmultiple.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js')
 const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
 const Formatter = require('../../modules/GameFormatter')
@@ -21,7 +22,7 @@ class PileFlipMultiple {
         ]);
 
         if (gameData.isdeleted) {
-            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
+            await interaction.editReply({ content: `There is no game in this channel.`, flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -31,14 +32,14 @@ class PileFlipMultiple {
         const pile = GameHelper.getGlobalPile(gameData, pileId)
 
         if (!pile) {
-            await interaction.editReply({ content: `Pile not found!`, ephemeral: true })
+            await interaction.editReply({ content: `Pile not found!`, flags: MessageFlags.Ephemeral })
             return
         }
 
         if (pile.cards.length < count) {
             await interaction.editReply({
                 content: `Not enough cards in ${pile.name}! (has ${pile.cards.length}, requested ${count})`,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             })
             return
         }
@@ -66,7 +67,7 @@ class PileFlipMultiple {
 
             if (!deck) {
                 pile.cards.unshift(...flippedCards)
-                await interaction.editReply({ content: 'No deck found to discard to. Use Game Board or a Custom Pile as destination.', ephemeral: true })
+                await interaction.editReply({ content: 'No deck found to discard to. Use Game Board or a Custom Pile as destination.', flags: MessageFlags.Ephemeral })
                 return
             }
             deck.piles.discard.cards.push(...flippedCards)
@@ -76,7 +77,7 @@ class PileFlipMultiple {
             const destPile = GameHelper.getGlobalPile(gameData, destination)
             if (!destPile) {
                 pile.cards.unshift(...flippedCards)
-                await interaction.editReply({ content: 'Destination pile not found!', ephemeral: true })
+                await interaction.editReply({ content: 'Destination pile not found!', flags: MessageFlags.Ephemeral })
                 return
             }
             destPile.cards.push(...flippedCards)

--- a/subcommands/cards/pilemove.js
+++ b/subcommands/cards/pilemove.js
@@ -2,7 +2,7 @@ const GameHelper = require('../../modules/GlobalGameHelper')
 const GameDB = require('../../db/anygame.js')
 const { find, findIndex } = require('lodash')
 const Formatter = require('../../modules/GameFormatter')
-const { EmbedBuilder, StringSelectMenuBuilder, ActionRowBuilder } = require('discord.js')
+const { EmbedBuilder, StringSelectMenuBuilder, ActionRowBuilder, MessageFlags } = require('discord.js')
 
 class PileMove {
     async execute(interaction, client) {
@@ -42,13 +42,13 @@ class PileMove {
         const gameData = await GameHelper.getGameData(client, interaction)
         
         if (gameData.isdeleted) {
-            await interaction.editReply({ content: `There is no game in this channel.`, ephemeral: true })
+            await interaction.editReply({ content: `There is no game in this channel.`, flags: MessageFlags.Ephemeral })
             return
         }
 
         const player = find(gameData.players, {userId: interaction.user.id})
         if (!player) {
-            await interaction.editReply({ content: "You must be a player in this game!", ephemeral: true })
+            await interaction.editReply({ content: "You must be a player in this game!", flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -56,18 +56,18 @@ class PileMove {
         const sourcePile = GameHelper.getGlobalPile(gameData, sourcePileId)
         
         if (!sourcePile) {
-            await interaction.editReply({ content: `Source pile not found!`, ephemeral: true })
+            await interaction.editReply({ content: `Source pile not found!`, flags: MessageFlags.Ephemeral })
             return
         }
 
         if (sourcePile.cards.length < 1) {
-            await interaction.editReply({ content: `No cards in ${sourcePile.name}!`, ephemeral: true })
+            await interaction.editReply({ content: `No cards in ${sourcePile.name}!`, flags: MessageFlags.Ephemeral })
             return
         }
 
         const destination = interaction.options.getString('destination')
         if (!destination) {
-            await interaction.editReply({ content: "You must specify a destination.", ephemeral: true })
+            await interaction.editReply({ content: "You must specify a destination.", flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -75,20 +75,20 @@ class PileMove {
 
         // Validate destination-specific requirements
         if (destination === 'playarea' && !destinationPlayerId) {
-            await interaction.editReply({ content: "You must specify a destination player when destination is 'Play Area'.", ephemeral: true })
+            await interaction.editReply({ content: "You must specify a destination player when destination is 'Play Area'.", flags: MessageFlags.Ephemeral })
             return
         }
 
         if (destination === 'playarea') {
             const destinationPlayer = find(gameData.players, { userId: destinationPlayerId })
             if (!destinationPlayer) {
-                await interaction.editReply({ content: "Destination player not found in the game.", ephemeral: true })
+                await interaction.editReply({ content: "Destination player not found in the game.", flags: MessageFlags.Ephemeral })
                 return
             }
         }
 
         if (sourcePileId === destination) {
-            await interaction.editReply({ content: "Cannot move cards to the same pile they came from.", ephemeral: true })
+            await interaction.editReply({ content: "Cannot move cards to the same pile they came from.", flags: MessageFlags.Ephemeral })
             return
         }
 
@@ -148,7 +148,7 @@ class PileMove {
             sourcePile.cards = newSourceCards
 
             if (movedCards.length === 0) {
-                await selectionInteraction.update({ content: "No valid cards were selected or an error occurred.", components: [], ephemeral: true })
+                await selectionInteraction.update({ content: "No valid cards were selected or an error occurred.", components: [], flags: MessageFlags.Ephemeral })
                 return
             }
 
@@ -160,7 +160,7 @@ class PileMove {
                 const destinationPlayer = find(gameData.players, { userId: destinationPlayerId })
                 if (!destinationPlayer) {
                     sourcePile.cards.push(...movedCards)
-                    await selectionInteraction.update({ content: 'Destination player not found! Cards returned to source pile.', components: [], ephemeral: true })
+                    await selectionInteraction.update({ content: 'Destination player not found! Cards returned to source pile.', components: [], flags: MessageFlags.Ephemeral })
                     return
                 }
                 if (!destinationPlayer.playArea) {
@@ -199,7 +199,7 @@ class PileMove {
                 if (!destinationPile) {
                     // Return cards to source pile if destination pile not found
                     sourcePile.cards.push(...movedCards)
-                    await selectionInteraction.update({ content: 'Destination pile not found! Cards returned to source pile.', components: [], ephemeral: true })
+                    await selectionInteraction.update({ content: 'Destination pile not found! Cards returned to source pile.', components: [], flags: MessageFlags.Ephemeral })
                     return
                 }
                 destinationPile.cards.push(...movedCards)
@@ -259,7 +259,7 @@ class PileMove {
                 // Show updated hand privately if destination was hand
                 if (destination === 'hand') {
                     const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
-                    const privateFollowup = { embeds: [...handInfo.embeds], ephemeral: true }
+                    const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
                     if (handInfo.attachments.length > 0) {
                         privateFollowup.files = [...handInfo.attachments]
                     }
@@ -274,10 +274,10 @@ class PileMove {
 
         } catch (e) {
             if (e.code === 'InteractionCollectorError') {
-                await interaction.editReply({ content: 'Card selection timed out.', components: [], ephemeral: true })
+                await interaction.editReply({ content: 'Card selection timed out.', components: [], flags: MessageFlags.Ephemeral })
             } else {
                 client.logger.log(e, 'error')
-                await interaction.editReply({ content: 'An error occurred during card selection for moving.', components: [], ephemeral: true })
+                await interaction.editReply({ content: 'An error occurred during card selection for moving.', components: [], flags: MessageFlags.Ephemeral })
             }
         }
     }

--- a/subcommands/cards/pilepeek.js
+++ b/subcommands/cards/pilepeek.js
@@ -12,7 +12,7 @@ class PilePeek {
         }
 
         const [, gameData] = await Promise.all([
-            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            interaction.deferReply(),
             GameHelper.getGameData(client, interaction)
         ]);
 

--- a/subcommands/cards/playareamove.js
+++ b/subcommands/cards/playareamove.js
@@ -172,7 +172,7 @@ module.exports = {
                 if (!pile) {
                     // Return cards to source play area if pile not found
                     sourcePlayer.playArea.push(...movedCards);
-                    await selectionInteraction.update({ content: 'Pile not found! Cards returned to source play area.', components: [], ephemeral: true });
+                    await selectionInteraction.update({ content: 'Pile not found! Cards returned to source play area.', components: [], flags: MessageFlags.Ephemeral });
                     return;
                 }
                 pile.cards.push(...movedCards);


### PR DESCRIPTION
## Summary
- `pile create` now resolves the original deferred interaction on success instead of leaving it stuck on "thinking..." (`GameStatusHelper.sendPublicStatusUpdate` gains an opt-in `resolveDeferredReply` flag; other call sites are unaffected since it defaults off)
- `pile peek`'s main reply is now public; the card-image follow-up stays ephemeral
- `GameFormatter.ImagefromUrlList` now degrades gracefully on per-image load failures (renders a "No Image" placeholder, reusing an existing pattern already used elsewhere in the file) instead of failing the whole render; `GameStatusHelper` falls back to a text-only reply if rendering still throws
- Swept the repo for deprecated `ephemeral: true` and replaced with `flags: MessageFlags.Ephemeral` across 8 files, adding/extending `MessageFlags` imports as needed

Fixes all 4 bugs tracked in `docs/known-bugs.md`.

## Test plan
- [ ] `/cards pile create` resolves the original interaction (no more stuck "thinking...") and posts the public status update
- [ ] `/cards pile peek` posts a public "Peeking at X" confirmation, with the actual card images arriving as an ephemeral follow-up
- [ ] Force an image load failure (e.g. bad card image URL) and confirm the command still responds with a "No Image" placeholder instead of failing silently
- [ ] Spot check `burn`, `flipmulti`, `gameboarddiscard`, `gameboardmove`, `pileflip`, `pileflipmultiple`, `pilemove`, `playareamove` ephemeral replies still behave as private messages, with no deprecation warning logged

Made with [Cursor](https://cursor.com)