### PR TITLE
perf(defer-reply): Phase 2 rollout for cards + genericgame subcommands

### DIFF
--- a/subcommands/cards/builderremove.js
+++ b/subcommands/cards/builderremove.js
@@ -63,16 +63,18 @@ class Remove {
       }
       
       await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
-      await interaction.reply(
-        { 
-          content: `${interaction.member.displayName} has Removed:`,
-          embeds: [
-            Formatter.oneCard(handCard),
-            ...Formatter.deckStatus2(gameData)
-          ]
-        }
-      )
-      var handInfo = await Formatter.playerSecretHandAndImages(gameData, currentPlayer)
+      const [, handInfo] = await Promise.all([
+        interaction.reply(
+          { 
+            content: `${interaction.member.displayName} has Removed:`,
+            embeds: [
+              Formatter.oneCard(handCard),
+              ...Formatter.deckStatus2(gameData)
+            ]
+          }
+        ),
+        Formatter.playerSecretHandAndImages(gameData, currentPlayer)
+      ])
       if (handInfo.attachments.length >0){
           await interaction.followUp({ 
               embeds: [...handInfo.embeds],

--- a/subcommands/cards/burn.js
+++ b/subcommands/cards/burn.js
@@ -17,9 +17,10 @@ class Burn {
             return;
         }
 
-        await interaction.deferReply();
-
-        let gameData = await GameHelper.getGameData(client, interaction);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ]);
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`});

--- a/subcommands/cards/configuredeck.js
+++ b/subcommands/cards/configuredeck.js
@@ -12,8 +12,10 @@ class Configure {
             let gameData = await GameHelper.getGameData(client, interaction)
             await GameHelper.getDeckAutocomplete(gameData, interaction)
         } else {
-            await interaction.deferReply()
-            let gameData = await GameHelper.getGameData(client, interaction)
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ])
             if (gameData.isdeleted) {
                 await interaction.editReply({ content: `There is no game in this channel.`})
                 return

--- a/subcommands/cards/deal.js
+++ b/subcommands/cards/deal.js
@@ -11,9 +11,10 @@ class Deal {
             let gameData = await GameHelper.getGameData(client, interaction)
             await GameHelper.getDeckAutocomplete(gameData, interaction)
         } else {
-            await interaction.deferReply()
-
-            let gameData = await GameHelper.getGameData(client, interaction)
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ])
             if (gameData.isdeleted) {
                 await interaction.editReply({ content: `There is no game in this channel.`})
                 return

--- a/subcommands/cards/deckprune.js
+++ b/subcommands/cards/deckprune.js
@@ -152,9 +152,10 @@ class DeckPrune {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})
@@ -249,13 +250,16 @@ class DeckPrune {
         }
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
-        
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData, {
-            content: `${interaction.member.displayName} removed ${prunedCardObjects.length} card(s) from the "${deck.name}" deck. All cards recalled and deck reshuffled. New deck size: ${deck.allCards.length} cards.`
-        })
+
+        // Main status send and the secondary render are independent of each other
+        const [, followup] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData, {
+                content: `${interaction.member.displayName} removed ${prunedCardObjects.length} card(s) from the "${deck.name}" deck. All cards recalled and deck reshuffled. New deck size: ${deck.allCards.length} cards.`
+            }),
+            Formatter.multiCard(prunedCardObjects, `Cards Removed from ${deck.name}`)
+        ])
 
         // Send ephemeral follow-up showing which cards were removed
-        let followup = await Formatter.multiCard(prunedCardObjects, `Cards Removed from ${deck.name}`)
         await interaction.followUp({ 
             embeds: [...followup[0]], 
             files: [...followup[1]],

--- a/subcommands/cards/deckremove.js
+++ b/subcommands/cards/deckremove.js
@@ -21,9 +21,10 @@ class DeckRemove {
             return
         }
 
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/discardall.js
+++ b/subcommands/cards/discardall.js
@@ -12,10 +12,13 @@ class DiscardAll {
   }
 
   async execute(interaction, client) {
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const deferPromise = interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     try {
-      let gameData = await GameHelper.getGameData(client, interaction);
+      const [, gameData] = await Promise.all([
+        deferPromise,
+        GameHelper.getGameData(client, interaction)
+      ]);
 
       if (gameData.isdeleted) {
         await interaction.editReply({ content: `There is no game in this channel.`});
@@ -66,14 +69,15 @@ class DiscardAll {
       // Save the game data after the primary action (discarding).
       await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
-      // First, send the private confirmation to the user.
-      await interaction.editReply({
-          content: `You have discarded all ${discardedCount} cards from your hand. Your hand is now empty.`});
-
-      // Now, handle the public status update using the helper.
-      await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-        content: `${interaction.member.displayName} has discarded all ${discardedCount} cards from their hand.`
-      });
+      // Private confirmation and public status update target independent sends
+      // (editReply vs. channel.send), so they can run concurrently.
+      await Promise.all([
+        interaction.editReply({
+          content: `You have discarded all ${discardedCount} cards from your hand. Your hand is now empty.`}),
+        GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+          content: `${interaction.member.displayName} has discarded all ${discardedCount} cards from their hand.`
+        })
+      ]);
 
     } catch (e) {
       console.error(e);

--- a/subcommands/cards/draftpass.js
+++ b/subcommands/cards/draftpass.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Pass {
     async execute(interaction, client) {
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/gameboardclear.js
+++ b/subcommands/cards/gameboardclear.js
@@ -6,9 +6,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class GameBoardClear {
     async execute(interaction, client) {
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/gameboarddiscard.js
+++ b/subcommands/cards/gameboarddiscard.js
@@ -30,9 +30,10 @@ class GameBoardDiscard {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/newdeck.js
+++ b/subcommands/cards/newdeck.js
@@ -17,9 +17,10 @@ class NewDeck {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/cards/pick.js
+++ b/subcommands/cards/pick.js
@@ -58,8 +58,6 @@ class Pick {
     if (pickedCards.length < 1){
       await interaction.editReply({ content: 'No cards selected', components: [] })
       return
-    } else {
-      await interaction.editReply({ content: 'Cards Picked Back Up!', components: [] })
     }
 
       let pickedCardsObjects = []
@@ -97,7 +95,10 @@ class Pick {
 
       await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-    let followup = await Formatter.multiCard(pickedCardsObjects, `Cards Picked Back Up by ${interaction.member.displayName}`)
+    const [, followup] = await Promise.all([
+      interaction.editReply({ content: 'Cards Picked Back Up!', components: [] }),
+      Formatter.multiCard(pickedCardsObjects, `Cards Picked Back Up by ${interaction.member.displayName}`)
+    ])
     await interaction.followUp({ embeds: [...followup[0]], files: [...followup[1]] })    
   }
 }

--- a/subcommands/cards/pileconfigure.js
+++ b/subcommands/cards/pileconfigure.js
@@ -11,9 +11,10 @@ class PileConfigure {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/pilecreate.js
+++ b/subcommands/cards/pilecreate.js
@@ -4,9 +4,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class PileCreate {
     async execute(interaction, client) {
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/piledelete.js
+++ b/subcommands/cards/piledelete.js
@@ -12,9 +12,10 @@ class PileDelete {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/piledraw.js
+++ b/subcommands/cards/piledraw.js
@@ -13,9 +13,10 @@ class PileDraw {
             return
         }
 
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ])
         const pileId = interaction.options.getString('pile')
         
         const player = find(gameData.players, {userId: interaction.user.id})
@@ -69,11 +70,12 @@ class PileDraw {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-        await interaction.editReply({ 
-            content: `You drew ${Formatter.cardShortName(drawnCard)} from ${pile.name}`})
-
-        // Show updated hand
-        const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+        // Main reply and the secondary hand render are independent of each other
+        const [, handInfo] = await Promise.all([
+            interaction.editReply({ 
+                content: `You drew ${Formatter.cardShortName(drawnCard)} from ${pile.name}`}),
+            Formatter.playerSecretHandAndImages(gameData, player)
+        ])
         const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
         if (handInfo.attachments.length > 0) {
             privateFollowup.files = [...handInfo.attachments]

--- a/subcommands/cards/pilelist.js
+++ b/subcommands/cards/pilelist.js
@@ -3,9 +3,10 @@ const {EmbedBuilder, MessageFlags} = require('discord.js')
 
 class PileList {
     async execute(interaction, client) {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/pilemove.js
+++ b/subcommands/cards/pilemove.js
@@ -37,9 +37,10 @@ class PileMove {
             return
         }
 
-        await interaction.deferReply({ ephemeral: false })
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply({ ephemeral: false }),
+            GameHelper.getGameData(client, interaction)
+        ])
         
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`, flags: MessageFlags.Ephemeral })
@@ -251,19 +252,26 @@ class PileMove {
                     publicMessage = `${interaction.member.displayName} moved ${successfullyMovedCards.length} card(s) from ${sourcePile.name} to ${destinationName}. (Card list too long to display).`
                 }
                 
-                await selectionInteraction.update({
-                    content: publicMessage,
-                    components: []
-                })
-
-                // Show updated hand privately if destination was hand
+                // Show updated hand privately if destination was hand - the update and the
+                // secondary hand render are independent of each other, so run concurrently
                 if (destination === 'hand') {
-                    const handInfo = await Formatter.playerSecretHandAndImages(gameData, player)
+                    const [, handInfo] = await Promise.all([
+                        selectionInteraction.update({
+                            content: publicMessage,
+                            components: []
+                        }),
+                        Formatter.playerSecretHandAndImages(gameData, player)
+                    ])
                     const privateFollowup = { embeds: [...handInfo.embeds], flags: MessageFlags.Ephemeral }
                     if (handInfo.attachments.length > 0) {
                         privateFollowup.files = [...handInfo.attachments]
                     }
                     await interaction.followUp(privateFollowup)
+                } else {
+                    await selectionInteraction.update({
+                        content: publicMessage,
+                        components: []
+                    })
                 }
             } else {
                 await selectionInteraction.update({

--- a/subcommands/cards/pileshuffle.js
+++ b/subcommands/cards/pileshuffle.js
@@ -12,9 +12,10 @@ class PileShuffle {
             return
         }
 
-        await interaction.deferReply()
-        
-        const gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/piletake.js
+++ b/subcommands/cards/piletake.js
@@ -52,7 +52,8 @@ class PileTake {
 
         const CardsSelected = await interaction.editReply({ 
             content: `Choose cards to take from ${pile.name}:`, 
-            components: [row],  
+            components: [row], 
+ 
             fetchReply: true 
         })
         
@@ -69,8 +70,6 @@ class PileTake {
         if (takenCards.length < 1) {
             await interaction.editReply({ content: 'No cards selected', components: [] })
             return
-        } else {
-            await interaction.editReply({ content: 'Cards Taken!', components: [] })
         }
 
         let takenCardObjects = []
@@ -114,7 +113,10 @@ class PileTake {
 
         await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData)
 
-        let followup = await Formatter.multiCard(takenCardObjects, `Cards Taken by ${interaction.member.displayName}`)
+        const [, followup] = await Promise.all([
+            interaction.editReply({ content: 'Cards Taken!', components: [] }),
+            Formatter.multiCard(takenCardObjects, `Cards Taken by ${interaction.member.displayName}`)
+        ])
         await interaction.followUp({ embeds: [...followup[0]], files: [...followup[1]] })
     }
 }

--- a/subcommands/cards/recall.js
+++ b/subcommands/cards/recall.js
@@ -15,9 +15,10 @@ class Recall {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/cards/shuffle.js
+++ b/subcommands/cards/shuffle.js
@@ -11,9 +11,10 @@ class Shuffle {
             return
         }
 
-        await interaction.deferReply()
-        
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ content: `There is no game in this channel.`})

--- a/subcommands/genericgame/addplayer.js
+++ b/subcommands/genericgame/addplayer.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class AddPlayer {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ 

--- a/subcommands/genericgame/firstplayer.js
+++ b/subcommands/genericgame/firstplayer.js
@@ -5,15 +5,17 @@ const { find } = require("lodash");
 
 class FirstPlayer {
   async execute(interaction, client) {
-    await interaction.deferReply();
     try {
+      const [, gameData] = await Promise.all([
+        interaction.deferReply(),
+        GameHelper.getGameData(client, interaction)
+      ]);
+
       const newFirstPlayer = interaction.options.getUser("player");
       if (!newFirstPlayer) {
         return interaction.editReply({
           content: "Please mention a player to set as first player."});
       }
-
-      let gameData = await GameHelper.getGameData(client, interaction);
 
       if (gameData.isdeleted) {
         return interaction.editReply({

--- a/subcommands/genericgame/history.js
+++ b/subcommands/genericgame/history.js
@@ -12,9 +12,10 @@ class History {
 
     async execute(interaction, client) {
         try {
-            await interaction.deferReply()
-            
-            const gameData = await GameHelper.getGameData(client, interaction)
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ])
 
             if (gameData.isdeleted) {
                 return await interaction.editReply({ 

--- a/subcommands/genericgame/historyadd.js
+++ b/subcommands/genericgame/historyadd.js
@@ -5,9 +5,10 @@ const GameHelper = require('../../modules/GlobalGameHelper')
 class HistoryAdd {
     async execute(interaction, client) {
         try {
-            await interaction.deferReply()
-            
-            const gameData = await GameHelper.getGameData(client, interaction)
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ])
 
             if (gameData.isdeleted) {
                 return await interaction.editReply({ 

--- a/subcommands/genericgame/newgameplus.js
+++ b/subcommands/genericgame/newgameplus.js
@@ -27,8 +27,11 @@ class NewGame {
       return;
     }
 
-    await interaction.deferReply();
-    let gameData = await client.getGameDataV2(interaction.guildId, 'game', interaction.channelId);
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply(),
+      client.getGameDataV2(interaction.guildId, 'game', interaction.channelId)
+    ]);
+    let gameData = rawGameData;
 
     if (gameData && !gameData.isdeleted) {
       gameData.bggGameId = search;
@@ -96,15 +99,17 @@ class NewGame {
       // Save game data before sending status messages
       await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
 
-      await interaction.editReply({
-        content: `New Game Created!`,
-        embeds: bgg.embeds,
-        files: bgg.attachments});
-
-      // Game Status Logic using the helper
-      await GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
-        content: content
-      });
+      // Main reply and the public status update are independent sends
+      // (editReply vs. channel.send), so they can run concurrently.
+      await Promise.all([
+        interaction.editReply({
+          content: `New Game Created!`,
+          embeds: bgg.embeds,
+          files: bgg.attachments}),
+        GameStatusHelper.sendPublicStatusUpdate(interaction, client, gameData, {
+          content: content
+        })
+      ]);
 
       if (bgg.otherAttachments.length > 0) {
         await interaction.followUp({

--- a/subcommands/genericgame/playarea.js
+++ b/subcommands/genericgame/playarea.js
@@ -16,8 +16,10 @@ module.exports = {
                 )),
     async execute(interaction) {
         try {
-            await interaction.deferReply();
-            const gameData = await GlobalGameHelper.getGameData(interaction.client, interaction);
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GlobalGameHelper.getGameData(interaction.client, interaction)
+            ]);
 
             if (gameData.isdeleted) {
                 return interaction.editReply({ content: "No active game found in this channel. Start a new game first."});

--- a/subcommands/genericgame/removeplayer.js
+++ b/subcommands/genericgame/removeplayer.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class RemovePlayer {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ 

--- a/subcommands/genericgame/reverse.js
+++ b/subcommands/genericgame/reverse.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Reverse {
   async execute(interaction, client) {
-    await interaction.deferReply()
-
-    let gameData = await GameHelper.getGameData(client, interaction)
+    const [, gameData] = await Promise.all([
+      interaction.deferReply(),
+      GameHelper.getGameData(client, interaction)
+    ])
 
     if (gameData.isdeleted) {
       await interaction.editReply({ 

--- a/subcommands/genericgame/status.js
+++ b/subcommands/genericgame/status.js
@@ -6,18 +6,22 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Status {
     static async execute(interaction, client) {
-        await interaction.deferReply()
-        const gameData = await client.getGameDataV2(interaction.guildId, 'game', interaction.channelId)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            client.getGameDataV2(interaction.guildId, 'game', interaction.channelId)
+        ])
 
         if (!gameData || gameData.isdeleted) {
             return await interaction.editReply({ content: "No game in progress!"})
         }
 
-        // Get secret tokens for the command caller
+        // Get secret tokens for the command caller - the main status send and
+        // the secondary token render are independent of each other
         const player = find(gameData.players, { userId: interaction.user.id })
-        const secretTokensEmbed = player ? await Formatter.playerSecretTokens(gameData, player) : null
-
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData, { content: "📊" });
+        const [, secretTokensEmbed] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData, { content: "📊" }),
+            player ? Formatter.playerSecretTokens(gameData, player) : Promise.resolve(null)
+        ]);
 
         // If the player has secret tokens, send them in an ephemeral followup
         if (secretTokensEmbed) {

--- a/subcommands/genericgame/test.js
+++ b/subcommands/genericgame/test.js
@@ -6,17 +6,21 @@ const GameStatusHelper = require('../../modules/GameStatusHelper');
 
 class Test {
     async execute(interaction, client) {
-        await interaction.deferReply();
-        const gameData = await client.getGameDataV2(interaction.guildId, 'game', interaction.channelId);
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            client.getGameDataV2(interaction.guildId, 'game', interaction.channelId)
+        ]);
 
         if (!gameData || gameData.isdeleted) {
             return await interaction.editReply({ content: "No game in progress!"});
         }
 
+        // Main status send and the secondary token render are independent of each other
         const player = find(gameData.players, { userId: interaction.user.id });
-        const secretTokensEmbed = player ? await Formatter.playerSecretTokens(gameData, player) : null;
-
-        await GameStatusHelper.sendGameStatus(interaction, client, gameData);
+        const [, secretTokensEmbed] = await Promise.all([
+            GameStatusHelper.sendGameStatus(interaction, client, gameData),
+            player ? Formatter.playerSecretTokens(gameData, player) : Promise.resolve(null)
+        ]);
 
         if (secretTokensEmbed) {
             await interaction.followUp({


### PR DESCRIPTION
## What

Part 2 of the defer-reply optimization rollout (see `docs/defer-reply-optimization.md`). Extends the two Promise.all-based optimizations to the remaining `subcommands/cards/*.js` files and all of `subcommands/genericgame/*.js` not covered by Phase 1 (#103) or the money-commands PR (#95).

1. **Concurrent deferReply + getGameData/getGameDataV2** \u2014 16 cards files + 7 genericgame files (opt #1 only)
2. **Concurrent main-reply + secondary-render** (`editReply`/`GameStatusHelper` send overlapped with a secondary `Formatter` render before the trailing `followUp`) \u2014 applied together with #1 on `deckprune.js`, `piledraw.js`, `pilemove.js`, `status.js`, `test.js`, `newgameplus.js`

Also fixes two gaps left over from Phase 1, where opt #1 landed but the trailing `editReply \u2192 render \u2192 followUp` chain was never parallelized:
- `cards/pick.js`
- `cards/piletake.js`
- `cards/builderremove.js` (same issue, on a direct `reply()` call)

## Why

Each of these commands pays the full ~200ms `deferReply` round-trip and/or a sequential secondary render back-to-back with the main send, even though the two are independent. Overlapping them recovers that dead time, same rationale as #95/#103. `status.js`/`test.js` (`/game status`) are likely high-traffic commands, so this should be a noticeable win there in particular.

## Scope / what's NOT in this PR

Deliberately out of scope, tracked as separate follow-up groups:
- `subcommands/players/*.js`, `subcommands/teams/*.js`
- `subcommands/money/reveal.js` (needs a small restructure, not a drop-in change)
- `slashcommands/{suggestions,bgg,releasenotes,rules}.js`, `events/modalSubmission.js`
- `cards/buildernew.js`/`builderadd.js` (low-value restructure) and `cards/simultaneousreveal.js` (optional per-player batching) \u2014 flagged as optional nice-to-haves, not required

## Testing

No logic changes beyond call sequencing \u2014 all edits preserve existing control flow, error handling, and variable usage. Verified every modified file parses cleanly (`node -c`). No automated test suite exists in this repo to run against live Discord/DB behavior; recommend manual smoke-testing `/game status`, `/cards pick`, `/cards pile move`, and `/cards pile take` since those have the most structural changes.

Made with [Cursor](https://cursor.com)