### PR TITLE
perf(defer-reply): Phase 2 rollout for players/teams, money/reveal, and misc commands

### DIFF
--- a/events/modalSubmission.js
+++ b/events/modalSubmission.js
@@ -11,8 +11,10 @@ module.exports = {
         const client = interaction.client;
 
         if (interaction.customId === 'colorall-modal') {
-            await interaction.deferReply();
-            let gameData = await GameHelper.getGameData(client, interaction);
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ]);
 
             if (gameData.isdeleted) {
                 await interaction.editReply({
@@ -54,8 +56,10 @@ module.exports = {
                 content: `Player colors updated successfully.`
             });
         } else if (interaction.customId === 'scoreall-modal') {
-            await interaction.deferReply();
-            let gameData = await GameHelper.getGameData(client, interaction);
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ]);
 
             if (gameData.isdeleted) {
                 await interaction.editReply({
@@ -97,8 +101,10 @@ module.exports = {
                 content: `Player scores updated successfully.`
             });
         } else if (interaction.customId === 'team-roster-modal') {
-            await interaction.deferReply();
-            let gameData = await GameHelper.getGameData(client, interaction);
+            const [, gameData] = await Promise.all([
+                interaction.deferReply(),
+                GameHelper.getGameData(client, interaction)
+            ]);
 
             if (gameData.isdeleted) {
                 await interaction.editReply({

--- a/slashcommands/info/bgg.js
+++ b/slashcommands/info/bgg.js
@@ -60,11 +60,12 @@ class BGG extends SlashCommand {
         }
 
         let ephemeral = BoardGameGeek.isEphemeral(interaction.options.getString("details"))
-        await interaction.deferReply({
-          ephemeral: ephemeral
-        });
-       
-        let bgg = await BoardGameGeek.CreateAndLoad(search, this.client, interaction)
+        const [, bgg] = await Promise.all([
+          interaction.deferReply({
+            ephemeral: ephemeral
+          }),
+          BoardGameGeek.CreateAndLoad(search, this.client, interaction)
+        ]);
         await bgg.LoadEmbeds(interaction.options.getString("details") || BoardGameGeek.DetailsEnum.ALL)
 
         await interaction.editReply({

--- a/slashcommands/info/releasenotes.js
+++ b/slashcommands/info/releasenotes.js
@@ -36,17 +36,14 @@ class ReleaseNotes extends SlashCommand {
     }
 
     try {
-      await interaction.deferReply();
       const version = interaction.options.getString("version");
-      let release;
-
-      if (version) {
-        const response = await fetch(`https://api.github.com/repos/furtivespy/games-discord-bot/releases/tags/${version}`);
-        release = await response.json();
-      } else {
-        const response = await fetch(`https://api.github.com/repos/furtivespy/games-discord-bot/releases/latest`);
-        release = await response.json();
-      }
+      const [, response] = await Promise.all([
+        interaction.deferReply(),
+        fetch(version
+          ? `https://api.github.com/repos/furtivespy/games-discord-bot/releases/tags/${version}`
+          : `https://api.github.com/repos/furtivespy/games-discord-bot/releases/latest`)
+      ]);
+      const release = await response.json();
 
       if (release.message === "Not Found") {
         await interaction.editReply({ content: `Release notes for version ${version} not found.`});

--- a/slashcommands/info/rules.js
+++ b/slashcommands/info/rules.js
@@ -27,14 +27,22 @@ class Rules extends SlashCommand {
   async execute(interaction) {
     try {
       const question = interaction.options.getString("question");
-      
-      // Defer reply since AI processing takes time
-      await interaction.deferReply();
+
+      // Defer reply (network round-trip) concurrently with fetching game context.
+      // getGameData failures are swallowed here (not surfaced via Promise.all) so a
+      // missing/broken game context still degrades gracefully instead of failing
+      // the whole command, matching the original try/catch behavior.
+      const [, gameData] = await Promise.all([
+        interaction.deferReply(),
+        GameHelper.getGameData(this.client, interaction).catch((e) => {
+          this.client.logger.warn("Could not get game context for rules command", { error: e.message });
+          return null;
+        })
+      ]);
 
       // Try to get current game context for better AI responses
       let bggData = null;
       try {
-        const gameData = await GameHelper.getGameData(this.client, interaction);
         if (gameData && gameData.bggGameId && !gameData.isdeleted) {
           bggData = await BoardGameGeek.CreateAndLoad(gameData.bggGameId, this.client, interaction)
         }

--- a/slashcommands/info/suggestions.js
+++ b/slashcommands/info/suggestions.js
@@ -250,13 +250,16 @@ class Suggest extends SlashCommand {
         return;
       }
 
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
       const subcommand = interaction.options.getSubcommand();
-      
+
+      const [, rawSuggestionData] = await Promise.all([
+        interaction.deferReply({ flags: MessageFlags.Ephemeral }),
+        this.client.getGameDataV2(interaction.guildId, 'suggest', "x")
+      ]);
       let suggestionData = Object.assign(
         {},
         cloneDeep(defaultSuggestionsObject),
-        await this.client.getGameDataV2(interaction.guildId, 'suggest', "x")
+        rawSuggestionData
       );
 
       // Migrate any existing suggestions that don't have all fields

--- a/subcommands/genericgame/firstplayer.js
+++ b/subcommands/genericgame/firstplayer.js
@@ -6,16 +6,17 @@ const { find } = require("lodash");
 class FirstPlayer {
   async execute(interaction, client) {
     try {
+      const newFirstPlayer = interaction.options.getUser("player");
+      if (!newFirstPlayer) {
+        await interaction.deferReply();
+        return interaction.editReply({
+          content: "Please mention a player to set as first player."});
+      }
+
       const [, gameData] = await Promise.all([
         interaction.deferReply(),
         GameHelper.getGameData(client, interaction)
       ]);
-
-      const newFirstPlayer = interaction.options.getUser("player");
-      if (!newFirstPlayer) {
-        return interaction.editReply({
-          content: "Please mention a player to set as first player."});
-      }
 
       if (gameData.isdeleted) {
         return interaction.editReply({

--- a/subcommands/money/reveal.js
+++ b/subcommands/money/reveal.js
@@ -4,18 +4,14 @@ const Formatter = require("../../modules/GameFormatter");
 
 class Reveal {
   async execute(interaction, client) {
-    await interaction.deferReply();
-    
-    if (interaction.options.getString("confirm") == "reveal") {
-      let gameData = Object.assign(
-        {},
-        cloneDeep(GameDB.defaultGameData),
-        await client.getGameDataV2(
-          interaction.guildId,
-          "game",
-          interaction.channelId
-        )
-      );
+    const confirm = interaction.options.getString("confirm");
+
+    if (confirm == "reveal") {
+      const [, rawGameData] = await Promise.all([
+        interaction.deferReply(),
+        client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+      ]);
+      let gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
 
       if (gameData.isdeleted) {
         await interaction.editReply({
@@ -28,6 +24,7 @@ class Reveal {
       await interaction.editReply({content: `Here's the money:\n${moneies}`})
 
     } else {
+      await interaction.deferReply();
       await interaction.editReply({ content: `Nothing revealed...`})
     }
   }

--- a/subcommands/players/add.js
+++ b/subcommands/players/add.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Add {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/players/color.js
+++ b/subcommands/players/color.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Color {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/players/first.js
+++ b/subcommands/players/first.js
@@ -5,15 +5,17 @@ const { find } = require("lodash");
 
 class First {
   async execute(interaction, client) {
-    await interaction.deferReply();
     try {
+      const [, gameData] = await Promise.all([
+        interaction.deferReply(),
+        GameHelper.getGameData(client, interaction)
+      ]);
+
       const newFirstPlayer = interaction.options.getUser("player");
       if (!newFirstPlayer) {
         return interaction.editReply({
           content: "Please mention a player to set as first player."});
       }
-
-      let gameData = await GameHelper.getGameData(client, interaction);
 
       if (gameData.isdeleted) {
         return interaction.editReply({

--- a/subcommands/players/first.js
+++ b/subcommands/players/first.js
@@ -6,16 +6,17 @@ const { find } = require("lodash");
 class First {
   async execute(interaction, client) {
     try {
+      const newFirstPlayer = interaction.options.getUser("player");
+      if (!newFirstPlayer) {
+        await interaction.deferReply();
+        return interaction.editReply({
+          content: "Please mention a player to set as first player."});
+      }
+
       const [, gameData] = await Promise.all([
         interaction.deferReply(),
         GameHelper.getGameData(client, interaction)
       ]);
-
-      const newFirstPlayer = interaction.options.getUser("player");
-      if (!newFirstPlayer) {
-        return interaction.editReply({
-          content: "Please mention a player to set as first player."});
-      }
 
       if (gameData.isdeleted) {
         return interaction.editReply({

--- a/subcommands/players/remove.js
+++ b/subcommands/players/remove.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Remove {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/players/score.js
+++ b/subcommands/players/score.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class AddScore {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({ 

--- a/subcommands/teams/color.js
+++ b/subcommands/teams/color.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Color {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/teams/jointeam.js
+++ b/subcommands/teams/jointeam.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class JoinTeam {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({

--- a/subcommands/teams/randomize.js
+++ b/subcommands/teams/randomize.js
@@ -5,9 +5,10 @@ const GameStatusHelper = require('../../modules/GameStatusHelper')
 
 class Randomize {
     async execute(interaction, client) {
-        await interaction.deferReply()
-
-        let gameData = await GameHelper.getGameData(client, interaction)
+        const [, gameData] = await Promise.all([
+            interaction.deferReply(),
+            GameHelper.getGameData(client, interaction)
+        ])
 
         if (gameData.isdeleted) {
             await interaction.editReply({


### PR DESCRIPTION
## What

Final part of the defer-reply optimization Phase 2 rollout (see `docs/defer-reply-optimization.md` and the earlier cards+genericgame PR #105). Combines the three remaining Phase 2 groups into one PR:

1. **players/teams** \u2014 `subcommands/players/{remove,first,color,add,score}.js`, `subcommands/teams/{color,jointeam,randomize}.js`. Sequential `deferReply`+`getGameData` \u2192 `Promise.all`.
2. **money/reveal.js** \u2014 needed a small restructure rather than a drop-in change: the data fetch is gated behind a `confirm === "reveal"` check, so it now only starts concurrently with `deferReply` inside that branch.
3. **misc** \u2014 `slashcommands/info/{suggestions,bgg,releasenotes,rules}.js` and `events/modalSubmission.js` (all 3 handler blocks: `colorall-modal`, `scoreall-modal`, `team-roster-modal`).

## Notable judgment calls

- `players/first.js`: moved `deferReply`+`getGameData` inside the file's existing `try/catch`, matching the precedent already set by `genericgame/firstplayer.js` in #105.
- `rules.js`: the straightforward opt-#1 pattern would have broken the original graceful-degradation behavior (a failed `getGameData` call previously let the command continue without game context instead of failing). Preserved that by attaching a local `.catch()` to the `getGameData` promise inside the `Promise.all`, so only `deferReply` failures propagate to the outer error handler, same as before.

## Scope / what's NOT in this PR

Deliberately out of scope, per the plan doc's optional/low-priority list:
- `cards/buildernew.js`/`builderadd.js` restructuring
- `cards/simultaneousreveal.js` per-player batching

This closes out the file list from `docs/defer-reply-optimization-phase2-plan.md`.

## Testing

No logic changes beyond call sequencing and the two restructures noted above \u2014 all edits preserve existing control flow, error handling, and messages. Verified every modified file parses cleanly (`node -c`). No automated test suite exists in this repo; recommend manual smoke-testing `/money reveal`, `/rules`, and one of the modal-based commands (e.g. team roster modal) since those have the most structural changes.

Made with [Cursor](https://cursor.com)