### PR TITLE
fix(genericgame/firstplayer): fetch game data only after validating the player option

### DIFF
--- a/subcommands/genericgame/firstplayer.js
+++ b/subcommands/genericgame/firstplayer.js
@@ -6,16 +6,17 @@ const { find } = require("lodash");
 class FirstPlayer {
   async execute(interaction, client) {
     try {
+      const newFirstPlayer = interaction.options.getUser("player");
+      if (!newFirstPlayer) {
+        await interaction.deferReply();
+        return interaction.editReply({
+          content: "Please mention a player to set as first player."});
+      }
+
       const [, gameData] = await Promise.all([
         interaction.deferReply(),
         GameHelper.getGameData(client, interaction)
       ]);
-
-      const newFirstPlayer = interaction.options.getUser("player");
-      if (!newFirstPlayer) {
-        return interaction.editReply({
-          content: "Please mention a player to set as first player."});
-      }
 
       if (gameData.isdeleted) {
         return interaction.editReply({


### PR DESCRIPTION
## What

Small follow-up fix found by a skeptical code review of the Phase 2 defer-reply rollout (PRs #105/#106).

When `subcommands/genericgame/firstplayer.js` was migrated to overlap `deferReply` with `GameHelper.getGameData` via `Promise.all` in #105, the fetch got moved ahead of the pre-existing `!newFirstPlayer` guard clause, so a request missing the `player` option now does a wasted DB read before returning the validation error.

The `player` option is `.setRequired(true)` in the slash command definition, so this path is normally unreachable through the standard Discord UI, but it's a real, easy-to-fix regression in the migration so it's worth closing out. The identical bug in the sibling `subcommands/players/first.js` was also found by the same review and has already been fixed on the still-open #106 branch.

## The fix

Move the synchronous option-validation check before the `Promise.all`, so `deferReply` still fires immediately either way, but `getGameData` only starts once we know it's actually needed:

```js
// After
const newFirstPlayer = interaction.options.getUser("player");
if (!newFirstPlayer) {
  await interaction.deferReply();
  return interaction.editReply({ content: "Please mention a player to set as first player."});
}

const [, gameData] = await Promise.all([
  interaction.deferReply(),
  GameHelper.getGameData(client, interaction)
]);
```

## Testing

Verified with `node -c`. No automated test suite exists in this repo to run against live Discord/DB behavior.

Made with [Cursor](https://cursor.com)