### PR TITLE
Add money deal command for starting funds

### DIFF
--- a/slashcommands/genericgame/money.js
+++ b/slashcommands/genericgame/money.js
@@ -3,6 +3,7 @@ const SlashCommand = require('../../base/SlashCommand.js')
 const { SlashCommandBuilder } = require('@discordjs/builders');
 
 const Check = require(`../../subcommands/money/check`)
+const Deal = require(`../../subcommands/money/deal`)
 const Pay = require(`../../subcommands/money/pay`)
 const Reveal = require(`../../subcommands/money/reveal`)
 const Spend = require(`../../subcommands/money/spend`)
@@ -30,6 +31,18 @@ class Money extends SlashCommand {
                 subcommand
                     .setName("check")
                     .setDescription("Check your current money")
+                )
+            .addSubcommand(subcommand =>
+                subcommand
+                    .setName("deal")
+                    .setDescription("Deal money to all players")
+                    .addIntegerOption(option =>
+                        option
+                            .setName("amount")
+                            .setDescription("Amount to give each player")
+                            .setMinValue(1)
+                            .setRequired(true)
+                    )
                 )
             .addSubcommand(subcommand =>
                 subcommand
@@ -63,6 +76,9 @@ class Money extends SlashCommand {
             switch (interaction.options.getSubcommand()) {
                 case "check":
                     await Check.execute(interaction, this.client)
+                    break
+                case "deal":
+                    await Deal.execute(interaction, this.client)
                     break
                 case "pay":
                     await Pay.execute(interaction, this.client)

--- a/subcommands/money/deal.js
+++ b/subcommands/money/deal.js
@@ -1,0 +1,58 @@
+const GameDB = require("../../db/anygame.js");
+const { cloneDeep } = require("lodash");
+const GameHelper = require("../../modules/GlobalGameHelper");
+
+class Deal {
+  async execute(interaction, client) {
+    const [, rawGameData] = await Promise.all([
+      interaction.deferReply(),
+      client.getGameDataV2(interaction.guildId, "game", interaction.channelId)
+    ]);
+    const gameData = Object.assign({}, cloneDeep(GameDB.defaultGameData), rawGameData);
+
+    if (gameData.isdeleted) {
+      await interaction.editReply({ content: "There is no game in this channel." });
+      return;
+    }
+
+    const amount = interaction.options.getInteger("amount");
+    if (amount < 1) {
+      await interaction.editReply({ content: "You can't deal less than $1!" });
+      return;
+    }
+
+    if (!gameData.players?.length) {
+      await interaction.editReply({ content: "There are no players in this game." });
+      return;
+    }
+
+    for (const player of gameData.players) {
+      player.money = (player.money || 0) + amount;
+    }
+
+    try {
+      const actorDisplayName = interaction.member?.displayName || interaction.user.username;
+
+      GameHelper.recordMove(
+        gameData,
+        interaction.user,
+        GameDB.ACTION_CATEGORIES.MONEY,
+        GameDB.ACTION_TYPES.DEAL,
+        `${actorDisplayName} dealt $${amount} to ${gameData.players.length} players`,
+        {
+          amount,
+          playerCount: gameData.players.length
+        }
+      );
+    } catch (error) {
+      console.warn("Failed to record money deal in history:", error);
+    }
+
+    await client.setGameDataV2(interaction.guildId, "game", interaction.channelId, gameData);
+    await interaction.editReply({
+      content: `Dealt $${amount} to ${gameData.players.length} players.`
+    });
+  }
+}
+
+module.exports = new Deal();

--- a/subcommands/money/help.js
+++ b/subcommands/money/help.js
@@ -13,6 +13,7 @@ Here's a list of commands to help you navigate the world of moolah. Let's get th
 
         const commands_and_conclusion_content = `\n**Money Commands:**
 
+*   **/money deal** 💵 - Give the same amount of money to every player. Perfect for starting funds!
 *   **/money take** 💰 - Need some cash? This command lets you take some money. Cha-ching! Hope you're feeling lucky! 🍀
 *   **/money spend** 💸 - Got that paper burning a hole in your pocket? Use this to spend your hard-earned cash. Treat yo' self! 🛍️
 *   **/money pay** 🤝 - Feeling generous (or maybe you lost a bet 😉)? Pay another player. Sharing is caring... sometimes!


### PR DESCRIPTION
## Summary
- add `/money deal` to give the same amount to every player
- record only aggregate deal details so private balances stay out of history
- document the new command in `/money help`

## Test plan
- [x] Validate modified JavaScript syntax
- [x] Verify command registration and minimum amount configuration
- [x] Verify balances update and empty-player handling with mocked game data
- [x] Confirm history details contain no player balances
- [x] Run lint and whitespace checks

Made with [Cursor](https://cursor.com)